### PR TITLE
fix: compilation timeout on larger projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -198,6 +198,12 @@
                     "default": true,
                     "markdownDescription": "Automatically recompiles the file after code action is applied"
                 },
+                "vscode-dataform-tools.defaultDataformCompileTime": {
+                    "type": "string",
+                    "default": "5m",
+                    "pattern": "^(\\d+[sm])+$",
+                     "markdownDescription": "Duration to allow project compilation to complete. Use format like '5m', '60s' etc. Passed to `dataform compile --json --timeout=<value>`"
+                },
                 "vscode-dataform-tools.formatdataformExecutablePath": {
                     "type": "string",
                     "default": "",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -143,7 +143,7 @@ export async function activate(context: vscode.ExtensionContext) {
             if (formatDataformCustomPath) {
                 executable = formatDataformCustomPath;
             }
-            if (executable === "formatdataform") { executableIsAvailable(executable) };
+            if (executable === "formatdataform") { executableIsAvailable(executable); };
             let document = vscode.window.activeTextEditor?.document;
             document?.save();
             let fileUri = document?.uri;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -231,7 +231,6 @@ export const getLineNumberWhereConfigBlockTerminates = async (): Promise<ConfigB
     }
 
     const document = editor.document;
-    document.save();
     const totalLines = document.lineCount;
 
     for (let i = 0; i < totalLines; i++) {
@@ -457,15 +456,19 @@ async function getMetadataForCurrentFile(fileName: string, compiledJson: Datafor
 
 
 function compileDataform(workspaceFolder: string): Promise<string> {
+    let defaultDataformCompileTime: string|undefined = vscode.workspace.getConfiguration('vscode-dataform-tools').get('defaultDataformCompileTime');
+    if(!defaultDataformCompileTime){
+        defaultDataformCompileTime = "5m";
+    }
     return new Promise((resolve, reject) => {
         let spawnedProcess;
         if (process.platform !== "win32") {
             const command = "dataform";
-            spawnedProcess = spawn(command, ["compile", workspaceFolder, "--json"]);
+            spawnedProcess = spawn(command, ["compile", workspaceFolder, "--json", `--timeout=${defaultDataformCompileTime}`]);
         } else {
             const command = "dataform.cmd";
             // windows seems to require shell: true
-            spawnedProcess = spawn(command, ["compile", workspaceFolder, "--json"], { shell: true });
+            spawnedProcess = spawn(command, ["compile", workspaceFolder, "--json", "--json", `--timeout=${defaultDataformCompileTime}`], { shell: true });
         }
 
         let stdOut = '';


### PR DESCRIPTION
Fixes https://github.com/ashish10alex/vscode-dataform-tools/issues/10 by adding a timeout option which has been defaulted to 5 minutes and can be configured in VS Code settings 

![CleanShot 2024-08-13 at 20 51 09@2x](https://github.com/user-attachments/assets/5549065b-ea3b-44cd-abfa-a89038cdcd8b)
