### PR TITLE
fix: compilation timeout when running a file / tag 

### DIFF
--- a/package.json
+++ b/package.json
@@ -202,7 +202,7 @@
                     "type": "string",
                     "default": "5m",
                     "pattern": "^(\\d+[sm])+$",
-                     "markdownDescription": "Duration to allow project compilation to complete. Use format like '5m', '60s' etc. Passed to `dataform compile --json --timeout=<value>`"
+                    "markdownDescription": "Duration to allow project compilation to complete. Use format like '5m', '60s' etc. Passed to `dataform compile --json --timeout=<value>`"
                 },
                 "vscode-dataform-tools.formatdataformExecutablePath": {
                     "type": "string",

--- a/package.json
+++ b/package.json
@@ -198,6 +198,12 @@
                     "default": true,
                     "markdownDescription": "Automatically recompiles the file after code action is applied"
                 },
+                "vscode-dataform-tools.defaultDataformCompileTime": {
+                    "type": "string",
+                    "default": "5m",
+                    "pattern": "^(\\d+[sm])+$",
+                     "markdownDescription": "Duration to allow project compilation to complete. Use format like '5m', '60s' etc. Passed to `dataform compile --json --timeout=<value>`"
+                },
                 "vscode-dataform-tools.formatdataformExecutablePath": {
                     "type": "string",
                     "default": "",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,15 +1,15 @@
 
 
-export function getRunTagsCommand(workspaceFolder: string, tag: string): string {
-    return `dataform run ${workspaceFolder} --tags=${tag}`;
+export function getRunTagsCommand(workspaceFolder: string, tag: string, dataformCompilationTimeoutVal:string): string {
+    return `dataform run ${workspaceFolder} --timeout=${dataformCompilationTimeoutVal} --tags=${tag}`;
 }
 
-export function getRunTagsWtDepsCommand(workspaceFolder: string, tag: string): string {
-    return `dataform run ${workspaceFolder} --tags=${tag} --include-deps`;
+export function getRunTagsWtDepsCommand(workspaceFolder: string, tag: string, dataformCompilationTimeoutVal:string ): string {
+    return `dataform run ${workspaceFolder} --timeout=${dataformCompilationTimeoutVal} --tags=${tag} --include-deps`;
 }
 
-export function getRunTagsWtDownstreamDepsCommand(workspaceFolder: string, tag: string): string {
-    return `dataform run ${workspaceFolder} --tags=${tag} --include-dependents`;
+export function getRunTagsWtDownstreamDepsCommand(workspaceFolder: string, tag: string, dataformCompilationTimeoutVal:string): string {
+    return `dataform run ${workspaceFolder} --timeout=${dataformCompilationTimeoutVal} --tags=${tag} --include-dependents`;
 }
 
 export function getFormatDataformFileCommand(cliPath:string, relativeFilePath: string): string {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -143,7 +143,7 @@ export async function activate(context: vscode.ExtensionContext) {
             if (formatDataformCustomPath) {
                 executable = formatDataformCustomPath;
             }
-            if (executable === "formatdataform") { executableIsAvailable(executable) };
+            if (executable === "formatdataform") { executableIsAvailable(executable); };
             let document = vscode.window.activeTextEditor?.document;
             document?.save();
             let fileUri = document?.uri;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,7 +31,7 @@ import { dataformCodeActionProviderDisposable, applyCodeActionUsingDiagnosticMes
 import { DataformRefDefinitionProvider } from './definitionProvider';
 import { DataformHoverProvider } from './hoverProvider';
 import { executablesToCheck, compiledSqlFilePath, tableQueryOffset } from './constants';
-import { executableIsAvailable, runCurrentFile, runCommandInTerminal, runCompilation, getFormatDataformExecutablePath } from './utils';
+import { executableIsAvailable, runCurrentFile, runCommandInTerminal, runCompilation, getFormatDataformExecutablePath, getDataformCompilationTimeoutFromConfig } from './utils';
 import { getStdoutFromCliRun, getWorkspaceFolder, compiledQueryWtDryRun, getDependenciesAutoCompletionItems, getDataformTags } from './utils';
 import { editorSyncDisposable } from './sync';
 import { sourcesAutoCompletionDisposable, dependenciesAutoCompletionDisposable, tagsAutoCompletionDisposable } from './completions';
@@ -205,7 +205,9 @@ export async function activate(context: vscode.ExtensionContext) {
                 }
 
                 if (!workspaceFolder) { return; }
-                let runTagsCmd = getRunTagsCommand(workspaceFolder, selection);
+
+                let defaultDataformCompileTime = getDataformCompilationTimeoutFromConfig();
+                let runTagsCmd = getRunTagsCommand(workspaceFolder, selection, defaultDataformCompileTime);
 
                 runCommandInTerminal(runTagsCmd);
             });
@@ -227,7 +229,8 @@ export async function activate(context: vscode.ExtensionContext) {
                 }
 
                 if (!workspaceFolder) { return; }
-                let runTagsWtDepsCommand = getRunTagsWtDepsCommand(workspaceFolder, selection);
+                let defaultDataformCompileTime = getDataformCompilationTimeoutFromConfig();
+                let runTagsWtDepsCommand = getRunTagsWtDepsCommand(workspaceFolder, selection, defaultDataformCompileTime);
 
                 runCommandInTerminal(runTagsWtDepsCommand);
             });
@@ -249,7 +252,8 @@ export async function activate(context: vscode.ExtensionContext) {
                 }
 
                 if (!workspaceFolder) { return; }
-                let runTagsWtDownstreamDepsCommand = getRunTagsWtDownstreamDepsCommand(workspaceFolder, selection);
+                let defaultDataformCompileTime = getDataformCompilationTimeoutFromConfig();
+                let runTagsWtDownstreamDepsCommand = getRunTagsWtDownstreamDepsCommand(workspaceFolder, selection, defaultDataformCompileTime);
 
                 runCommandInTerminal(runTagsWtDownstreamDepsCommand);
             });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -231,7 +231,6 @@ export const getLineNumberWhereConfigBlockTerminates = async (): Promise<ConfigB
     }
 
     const document = editor.document;
-    document.save();
     const totalLines = document.lineCount;
 
     for (let i = 0; i < totalLines; i++) {
@@ -457,15 +456,19 @@ async function getMetadataForCurrentFile(fileName: string, compiledJson: Datafor
 
 
 function compileDataform(workspaceFolder: string): Promise<string> {
+    let defaultDataformCompileTime: string|undefined = vscode.workspace.getConfiguration('vscode-dataform-tools').get('defaultDataformCompileTime');
+    if(!defaultDataformCompileTime){
+        defaultDataformCompileTime = "5m";
+    }
     return new Promise((resolve, reject) => {
         let spawnedProcess;
         if (process.platform !== "win32") {
             const command = "dataform";
-            spawnedProcess = spawn(command, ["compile", workspaceFolder, "--json"]);
+            spawnedProcess = spawn(command, ["compile", workspaceFolder, "--json", `--timeout=${defaultDataformCompileTime}`]);
         } else {
             const command = "dataform.cmd";
             // windows seems to require shell: true
-            spawnedProcess = spawn(command, ["compile", workspaceFolder, "--json"], { shell: true });
+            spawnedProcess = spawn(command, ["compile", workspaceFolder, "--json", "--json", `--timeout=${defaultDataformCompileTime}`], { shell: true });
         }
 
         let stdOut = '';


### PR DESCRIPTION
Fixes https://github.com/ashish10alex/vscode-dataform-tools/issues/10 by adding `--timeout` flag which can optionally be configured in vscode settings similar to the fix for compilation in https://github.com/ashish10alex/vscode-dataform-tools/pull/11
