### PR TITLE
feat: Ability to choose more options when running file(s) / tag(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Open vscode command pallet by pressing <kbd>CTLR</kbd> + <kbd>SHIFT</kbd> + <kbd
 | `Dataform: Run current tag with dependencies`          |
 | `Dataform: Run current tag with dependents`            |
 | `Dataform: Format current file`                        |
+| `Dataform: Run file(s) / tag(s) with options`          |
 
 
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
         "onCommand:extension.enable",
         "onCommand:extension.disable",
         "onCommand:extension.runCurrentFile",
-        "onCommand:extension.rurunMultipleFiles",
         "onCommand:extension.showDependentsInGraph",
         "onCommand:extension.runCurrentFileWtDeps",
         "onCommand:extension.runCurrentFileWtDownstreamDeps",
@@ -113,12 +112,6 @@
                 "category": "Dataform",
                 "title": "Run current file",
                 "icon": "$(play)",
-                "group": "navigation"
-            },
-            {
-                "command": "vscode-dataform-tools.runMultipleFiles",
-                "category": "Dataform",
-                "title": "Run multiple files",
                 "group": "navigation"
             },
             {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
         "onCommand:extension.runTag",
         "onCommand:extension.runTagWtDeps",
         "onCommand:extension.runTagWtDownstreamDeps",
-        "onCommand:extension.formatCurrentfile"
+        "onCommand:extension.formatCurrentfile",
+        "onCommand:extension.multiStageSelection"
     ],
     "main": "./out/extension.js",
     "contributes": {
@@ -71,6 +72,11 @@
                 "command": "vscode-dataform-tools.enable",
                 "category": "Dataform",
                 "title": "Enable extension"
+            },
+            {
+                "command": "vscode-dataform-tools.multiStageSelection",
+                "category": "Dataform",
+                "title": "Multi-Stage Selection"
             },
             {
                 "command": "vscode-dataform-tools.formatCurrentfile",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "onCommand:extension.runTagWtDeps",
         "onCommand:extension.runTagWtDownstreamDeps",
         "onCommand:extension.formatCurrentfile",
-        "onCommand:extension.multiStageSelection"
+    "onCommand:extension.runFilesTagsWtOptions"
     ],
     "main": "./out/extension.js",
     "contributes": {
@@ -73,9 +73,9 @@
                 "title": "Enable extension"
             },
             {
-                "command": "vscode-dataform-tools.multiStageSelection",
+                "command": "vscode-dataform-tools.runFilesTagsWtOptions",
                 "category": "Dataform",
-                "title": "Multi-Stage Selection"
+                "title": "Run file(s) / tag(s) with options"
             },
             {
                 "command": "vscode-dataform-tools.formatCurrentfile",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -4,6 +4,23 @@ export function getRunTagsCommand(workspaceFolder: string, tag: string, dataform
     return `dataform run ${workspaceFolder} --timeout=${dataformCompilationTimeoutVal} --tags=${tag}`;
 }
 
+export function getRunMultipleTagsCommand(workspaceFolder: string, tags: string, dataformCompilationTimeoutVal:string, includDependencies:boolean, includeDownstreamDependents:boolean, fullRefresh:boolean ): string {
+    let runMultiTagsCommand = `dataform run ${workspaceFolder} --timeout=${dataformCompilationTimeoutVal}`;
+    for (let tag of tags) {
+        runMultiTagsCommand += ` --tags=${tag}`;
+    }
+    if (includDependencies) {
+        runMultiTagsCommand += ` --include-deps`;
+    }
+    if (includeDownstreamDependents) {
+        runMultiTagsCommand += ` --include-dependents`;
+    }
+    if (fullRefresh) {
+        runMultiTagsCommand += ` --full-refresh`;
+    }
+    return runMultiTagsCommand;
+}
+
 export function getRunTagsWtDepsCommand(workspaceFolder: string, tag: string, dataformCompilationTimeoutVal:string ): string {
     return `dataform run ${workspaceFolder} --timeout=${dataformCompilationTimeoutVal} --tags=${tag} --include-deps`;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -143,7 +143,7 @@ export async function activate(context: vscode.ExtensionContext) {
         );
 
         runMultipleFileCommandDisposable = vscode.commands.registerCommand('vscode-dataform-tools.runMultipleFiles', async() => {
-            runMultipleFiles();
+            runMultipleFiles(false, false, false);
         });
         context.subscriptions.push(runMultipleFileCommandDisposable);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -40,7 +40,7 @@ import { editorSyncDisposable } from './sync';
 import { sourcesAutoCompletionDisposable, dependenciesAutoCompletionDisposable, tagsAutoCompletionDisposable } from './completions';
 import { getRunTagsCommand, getRunTagsWtDepsCommand, getRunTagsWtDownstreamDepsCommand } from './commands';
 import { getMetadataForSqlxFileBlocks } from './sqlxFileParser';
-import { multiStageSelectionHandler } from './multiStageSelector';
+import { runFilesTagsWtOptions } from './runFilesTagsWtOptions';
 
 // This method is called when your extension is activated
 export async function activate(context: vscode.ExtensionContext) {
@@ -138,8 +138,9 @@ export async function activate(context: vscode.ExtensionContext) {
         runCurrentFileCommandDisposable = vscode.commands.registerCommand('vscode-dataform-tools.runCurrentFile', () => { runCurrentFile(false, false, false); });
         context.subscriptions.push(runCurrentFileCommandDisposable);
 
+        //TODO: Do we need to create a disposable variable ?
         context.subscriptions.push(
-            vscode.commands.registerCommand('vscode-dataform-tools.multiStageSelection', multiStageSelectionHandler)
+            vscode.commands.registerCommand('vscode-dataform-tools.runFilesTagsWtOptions', runFilesTagsWtOptions)
         );
 
         /**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -40,6 +40,7 @@ import { editorSyncDisposable } from './sync';
 import { sourcesAutoCompletionDisposable, dependenciesAutoCompletionDisposable, tagsAutoCompletionDisposable } from './completions';
 import { getRunTagsCommand, getRunTagsWtDepsCommand, getRunTagsWtDownstreamDepsCommand } from './commands';
 import { getMetadataForSqlxFileBlocks } from './sqlxFileParser';
+import { multiStageSelectionHandler } from './multiStageSelector';
 
 // This method is called when your extension is activated
 export async function activate(context: vscode.ExtensionContext) {
@@ -136,6 +137,10 @@ export async function activate(context: vscode.ExtensionContext) {
 
         runCurrentFileCommandDisposable = vscode.commands.registerCommand('vscode-dataform-tools.runCurrentFile', () => { runCurrentFile(false, false); });
         context.subscriptions.push(runCurrentFileCommandDisposable);
+
+        context.subscriptions.push(
+            vscode.commands.registerCommand('vscode-dataform-tools.multiStageSelection', multiStageSelectionHandler)
+        );
 
         runMultipleFileCommandDisposable = vscode.commands.registerCommand('vscode-dataform-tools.runMultipleFiles', async() => {
             workspaceFolder = getWorkspaceFolder();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,7 +34,7 @@ import { dataformCodeActionProviderDisposable, applyCodeActionUsingDiagnosticMes
 import { DataformRefDefinitionProvider } from './definitionProvider';
 import { DataformHoverProvider } from './hoverProvider';
 import { executablesToCheck, compiledSqlFilePath} from './constants';
-import { getWorkspaceFolder, formatSqlxFile, compiledQueryWtDryRun, getDependenciesAutoCompletionItems, getDataformTags, writeContentsToFile, fetchGitHubFileContent, getSqlfluffConfigPathFromSettings, getFileNameFromDocument, getVSCodeDocument, getMetadataForCurrentFile, getDataformActionCmdFromActionList, getAllFilesWtAnExtension, runMultipleFiles } from './utils';
+import { getWorkspaceFolder, formatSqlxFile, compiledQueryWtDryRun, getDependenciesAutoCompletionItems, getDataformTags, writeContentsToFile, fetchGitHubFileContent, getSqlfluffConfigPathFromSettings, getFileNameFromDocument, getVSCodeDocument} from './utils';
 import { executableIsAvailable, runCurrentFile, runCommandInTerminal, runCompilation, getDataformCompilationTimeoutFromConfig, checkIfFileExsists } from './utils';
 import { editorSyncDisposable } from './sync';
 import { sourcesAutoCompletionDisposable, dependenciesAutoCompletionDisposable, tagsAutoCompletionDisposable } from './completions';
@@ -141,11 +141,6 @@ export async function activate(context: vscode.ExtensionContext) {
         context.subscriptions.push(
             vscode.commands.registerCommand('vscode-dataform-tools.multiStageSelection', multiStageSelectionHandler)
         );
-
-        runMultipleFileCommandDisposable = vscode.commands.registerCommand('vscode-dataform-tools.runMultipleFiles', async() => {
-            runMultipleFiles(false, false, false);
-        });
-        context.subscriptions.push(runMultipleFileCommandDisposable);
 
         /**
          * Takes ~2 seconds as we compile the project and dry run the file to safely format the .sqlx file to avoid loosing user code due to incorrect parsing due to unexptected block terminations, etc.
@@ -332,9 +327,6 @@ export async function activate(context: vscode.ExtensionContext) {
             }
             if (runCurrentFileCommandDisposable !== null) {
                 runCurrentFileCommandDisposable.dispose();
-            }
-            if (runMultipleFileCommandDisposable !== null){
-                runMultipleFileCommandDisposable.dispose();
             }
             if (runCurrentFileWtDepsCommandDisposable !== null) {
                 runCurrentFileWtDepsCommandDisposable.dispose();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -135,7 +135,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
         context.subscriptions.push(editorSyncDisposable);
 
-        runCurrentFileCommandDisposable = vscode.commands.registerCommand('vscode-dataform-tools.runCurrentFile', () => { runCurrentFile(false, false); });
+        runCurrentFileCommandDisposable = vscode.commands.registerCommand('vscode-dataform-tools.runCurrentFile', () => { runCurrentFile(false, false, false); });
         context.subscriptions.push(runCurrentFileCommandDisposable);
 
         context.subscriptions.push(
@@ -159,13 +159,9 @@ export async function activate(context: vscode.ExtensionContext) {
             let selectedFiles = await vscode.window.showQuickPick(fileList, options);
             if (selectedFiles){
                 for (let i = 0; i < selectedFiles.length; i ++){
-                    let filepath = selectedFiles[i];
-                    if (!filepath) {
-                        return;
-                    }
-                    let filename = path.basename(filepath).split('.')[0];
-                    if (dataformCompiledJson){
-                        tableMetadatas.push(await getMetadataForCurrentFile(filename, dataformCompiledJson));
+                    let relativeFilepath = selectedFiles[i];
+                    if (dataformCompiledJson && relativeFilepath){
+                        tableMetadatas.push(await getMetadataForCurrentFile(relativeFilepath, dataformCompiledJson));
                     }
                 }
             }
@@ -180,7 +176,7 @@ export async function activate(context: vscode.ExtensionContext) {
             });
             let dataformCompilationTimeoutVal = getDataformCompilationTimeoutFromConfig();
             let dataformActionCmd = "";
-            dataformActionCmd = getDataformActionCmdFromActionList(actionsList, workspaceFolder, dataformCompilationTimeoutVal, false, false);
+            dataformActionCmd = getDataformActionCmdFromActionList(actionsList, workspaceFolder, dataformCompilationTimeoutVal, false, false, false);
             runCommandInTerminal(dataformActionCmd);
             });
         context.subscriptions.push(runMultipleFileCommandDisposable);
@@ -242,10 +238,10 @@ export async function activate(context: vscode.ExtensionContext) {
         });
         context.subscriptions.push(formatCurrentFileDisposable);
 
-        runCurrentFileWtDepsCommandDisposable = vscode.commands.registerCommand('vscode-dataform-tools.runCurrentFileWtDeps', () => { runCurrentFile(true, false); });
+        runCurrentFileWtDepsCommandDisposable = vscode.commands.registerCommand('vscode-dataform-tools.runCurrentFileWtDeps', () => { runCurrentFile(true, false, false); });
         context.subscriptions.push(runCurrentFileWtDepsCommandDisposable);
 
-        runCurrentFileWtDownstreamDepsCommandDisposable = vscode.commands.registerCommand('vscode-dataform-tools.runCurrentFileWtDownstreamDeps', () => { runCurrentFile(false, true); });
+        runCurrentFileWtDownstreamDepsCommandDisposable = vscode.commands.registerCommand('vscode-dataform-tools.runCurrentFileWtDownstreamDeps', () => { runCurrentFile(false, true, false); });
         context.subscriptions.push(runCurrentFileWtDownstreamDepsCommandDisposable);
 
 

--- a/src/multiStageSelector.ts
+++ b/src/multiStageSelector.ts
@@ -3,14 +3,13 @@ import { getDataformCompilationTimeoutFromConfig, getMultipleFileSelection, getW
 import { getRunTagsWtDepsCommand } from './commands';
 
 export async function multiStageSelectionHandler() {
-    // First stage selection
     const firstStageOptions = ["run current file", "run multiple files" , "run a tag"];
     const firstStageSelection = await vscode.window.showQuickPick(firstStageOptions, {
         placeHolder: 'Select an option'
     });
 
     if (!firstStageSelection) {
-        return; // User cancelled the selection
+        return;
     }
 
     let tagSelection: string | undefined;
@@ -29,7 +28,6 @@ export async function multiStageSelectionHandler() {
         multipleFileSelection = await getMultipleFileSelection(workspaceFolder);
     }
 
-    // Second stage selection based on first stage
     let secondStageOptions: string[];
     if (firstStageSelection || tagSelection) {
         secondStageOptions = ["default", "include dependents", "include dependencies"];
@@ -42,10 +40,9 @@ export async function multiStageSelectionHandler() {
     });
 
     if (!secondStageSelection) {
-        return; // User cancelled the selection
+        return;
     }
 
-    // Second stage selection based on first stage
     let thirdStageOptions: string[];
     if (firstStageSelection) {
         thirdStageOptions = ["no", "yes"];
@@ -61,8 +58,6 @@ export async function multiStageSelectionHandler() {
         return;
     }
 
-    // Handle the final selection
-    vscode.window.showInformationMessage(`You selected: ${firstStageSelection} > ${tagSelection} > ${secondStageSelection} > ${thirdStageSelection}`);
     let includeDependents = false;
     let includeDependencies = false;
     let fullRefresh = false;

--- a/src/multiStageSelector.ts
+++ b/src/multiStageSelector.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { getDataformCompilationTimeoutFromConfig, getWorkspaceFolder, runCommandInTerminal, runCurrentFile } from './utils';
+import { getDataformCompilationTimeoutFromConfig, getWorkspaceFolder, runCommandInTerminal, runCurrentFile, runMultipleFiles } from './utils';
 import { getRunTagsWtDepsCommand } from './commands';
 
 export async function multiStageSelectionHandler() {
@@ -76,5 +76,7 @@ export async function multiStageSelectionHandler() {
         let defaultDataformCompileTime = getDataformCompilationTimeoutFromConfig();
         let runTagsWtDepsCommand = getRunTagsWtDepsCommand(workspaceFolder, tagSelection, defaultDataformCompileTime);
         runCommandInTerminal(runTagsWtDepsCommand);
+    } else if (firstStageSelection === "run multiple files"){
+      runMultipleFiles(includeDependencies, includeDependents, fullRefresh);
     }
 }

--- a/src/multiStageSelector.ts
+++ b/src/multiStageSelector.ts
@@ -1,48 +1,80 @@
 import * as vscode from 'vscode';
+import { getDataformCompilationTimeoutFromConfig, getWorkspaceFolder, runCommandInTerminal, runCurrentFile } from './utils';
+import { getRunTagsWtDepsCommand } from './commands';
 
 export async function multiStageSelectionHandler() {
     // First stage selection
-    const firstStageOptions = dataformTags;
+    const firstStageOptions = ["run current file", "run a tag"];
     const firstStageSelection = await vscode.window.showQuickPick(firstStageOptions, {
-      placeHolder: 'Select an option'
+        placeHolder: 'Select an option'
     });
-  
+
     if (!firstStageSelection) {
-      return; // User cancelled the selection
+        return; // User cancelled the selection
     }
-  
+
+    let tagSelection: string | undefined;
+    if (firstStageSelection === "run a tag") {
+        const tagOptions = dataformTags;
+        tagSelection = await vscode.window.showQuickPick(tagOptions, {
+            placeHolder: 'Select a tag'
+        });
+    }
+
     // Second stage selection based on first stage
     let secondStageOptions: string[];
-    if (firstStageSelection) {
-      secondStageOptions = ["default", "include dependents", "include dependencies"];
-    } else{
-      return;
+    if (firstStageSelection || tagSelection) {
+        secondStageOptions = ["default", "include dependents", "include dependencies"];
+    } else {
+        return;
     }
-  
+
     const secondStageSelection = await vscode.window.showQuickPick(secondStageOptions, {
-      placeHolder: `select run type`
+        placeHolder: `select run type`
     });
 
     if (!secondStageSelection) {
-      return; // User cancelled the selection
+        return; // User cancelled the selection
     }
 
     // Second stage selection based on first stage
     let thirdStageOptions: string[];
     if (firstStageSelection) {
-      thirdStageOptions = ["no", "yes"];
-    } else{
-      return;
+        thirdStageOptions = ["no", "yes"];
+    } else {
+        return;
     }
 
     const thirdStageSelection = await vscode.window.showQuickPick(thirdStageOptions, {
-      placeHolder: `full refresh`
+        placeHolder: `full refresh`
     });
 
-    if (!thirdStageSelection){
-      return;
+    if (!thirdStageSelection) {
+        return;
     }
-  
+
     // Handle the final selection
-    vscode.window.showInformationMessage(`You selected: ${firstStageSelection} > ${secondStageSelection} > ${thirdStageSelection}`);
-  }
+    vscode.window.showInformationMessage(`You selected: ${firstStageSelection} > ${tagSelection} > ${secondStageSelection} > ${thirdStageSelection}`);
+    let includeDependents = false;
+    let includeDependencies = false;
+    let fullRefresh = false;
+    if (secondStageSelection === "include dependents") {
+        includeDependents = true;
+    }
+    if (secondStageSelection === "include dependencies") {
+        includeDependencies = true;
+    }
+    if (thirdStageSelection === "yes") {
+        fullRefresh = true;
+    }
+    if (firstStageSelection === "run current file") {
+        runCurrentFile(includeDependencies, includeDependents, fullRefresh);
+    } else if (firstStageSelection === "run a tag" && tagSelection) {
+        // TODO: make this a function and also use the abstraction in extension.ts
+        let workspaceFolder = getWorkspaceFolder();
+        if (!workspaceFolder) { return; }
+        let defaultDataformCompileTime = getDataformCompilationTimeoutFromConfig();
+        let runTagsWtDepsCommand = getRunTagsWtDepsCommand(workspaceFolder, tagSelection, defaultDataformCompileTime);
+        runCommandInTerminal(runTagsWtDepsCommand);
+    }
+}

--- a/src/multiStageSelector.ts
+++ b/src/multiStageSelector.ts
@@ -4,7 +4,7 @@ import { getRunTagsWtDepsCommand } from './commands';
 
 export async function multiStageSelectionHandler() {
     // First stage selection
-    const firstStageOptions = ["run current file", "run a tag"];
+    const firstStageOptions = ["run current file", "run multiple files" , "run a tag"];
     const firstStageSelection = await vscode.window.showQuickPick(firstStageOptions, {
         placeHolder: 'Select an option'
     });

--- a/src/multiStageSelector.ts
+++ b/src/multiStageSelector.ts
@@ -1,0 +1,48 @@
+import * as vscode from 'vscode';
+
+export async function multiStageSelectionHandler() {
+    // First stage selection
+    const firstStageOptions = dataformTags;
+    const firstStageSelection = await vscode.window.showQuickPick(firstStageOptions, {
+      placeHolder: 'Select an option'
+    });
+  
+    if (!firstStageSelection) {
+      return; // User cancelled the selection
+    }
+  
+    // Second stage selection based on first stage
+    let secondStageOptions: string[];
+    if (firstStageSelection) {
+      secondStageOptions = ["default", "include dependents", "include dependencies"];
+    } else{
+      return;
+    }
+  
+    const secondStageSelection = await vscode.window.showQuickPick(secondStageOptions, {
+      placeHolder: `select run type`
+    });
+
+    if (!secondStageSelection) {
+      return; // User cancelled the selection
+    }
+
+    // Second stage selection based on first stage
+    let thirdStageOptions: string[];
+    if (firstStageSelection) {
+      thirdStageOptions = ["no", "yes"];
+    } else{
+      return;
+    }
+
+    const thirdStageSelection = await vscode.window.showQuickPick(thirdStageOptions, {
+      placeHolder: `full refresh`
+    });
+
+    if (!thirdStageSelection){
+      return;
+    }
+  
+    // Handle the final selection
+    vscode.window.showInformationMessage(`You selected: ${firstStageSelection} > ${secondStageSelection} > ${thirdStageSelection}`);
+  }

--- a/src/runFilesTagsWtOptions.ts
+++ b/src/runFilesTagsWtOptions.ts
@@ -77,8 +77,8 @@ export async function runFilesTagsWtOptions() {
 
     if (firstStageSelection === "run current file") {
         runCurrentFile(includeDependencies, includeDependents, fullRefresh);
-    } else if (firstStageSelection === "run a tag" && tagSelection) {
-        // TODO: make this a function and also use the abstraction in extension.ts
+    } else if (firstStageSelection === "run a tag") {
+        if(!tagSelection){return;};
         let defaultDataformCompileTime = getDataformCompilationTimeoutFromConfig();
         let runTagsWtDepsCommand = getRunTagsWtDepsCommand(workspaceFolder, tagSelection, defaultDataformCompileTime);
         runCommandInTerminal(runTagsWtDepsCommand);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -885,7 +885,7 @@ export async function formatSqlxFile(document:vscode.TextDocument, metadataForSq
     });
 }
 
-export async function runMultipleFiles(){
+export async function runMultipleFiles(includDependencies: boolean, includeDownstreamDependents: boolean, fullRefresh: boolean){
     let workspaceFolder = getWorkspaceFolder();
     if (!workspaceFolder){
         return;
@@ -919,7 +919,7 @@ export async function runMultipleFiles(){
     });
     let dataformCompilationTimeoutVal = getDataformCompilationTimeoutFromConfig();
     let dataformActionCmd = "";
-    dataformActionCmd = getDataformActionCmdFromActionList(actionsList, workspaceFolder, dataformCompilationTimeoutVal, false, false, false);
+    dataformActionCmd = getDataformActionCmdFromActionList(actionsList, workspaceFolder, dataformCompilationTimeoutVal, includDependencies, includeDownstreamDependents, fullRefresh);
     runCommandInTerminal(dataformActionCmd);
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,6 +10,7 @@ import { setDiagnostics } from './setDiagnostics';
 import { assertionQueryOffset, tableQueryOffset, sqlFileToFormatPath } from './constants';
 import { getMetadataForSqlxFileBlocks } from './sqlxFileParser';
 import { GitHubContentResponse } from './types';
+import { getRunMultipleTagsCommand } from './commands';
 
 let supportedExtensions = ['sqlx', 'js'];
 
@@ -883,6 +884,21 @@ export async function formatSqlxFile(document:vscode.TextDocument, metadataForSq
         vscode.window.showErrorMessage(`Error formatting: ${err}`);
         return;
     });
+}
+
+export async function  getMultipleTagsSelection(){
+    let options  = {
+        canPickMany: true,
+        ignoreFocusOut: true,
+    };
+    let selectedTags = await vscode.window.showQuickPick(dataformTags, options);
+    return selectedTags;
+}
+
+export async function runMultipleTagsFromSelection(workspaceFolder:string, selectedTags:string, includDependencies:boolean, includeDownstreamDependents:boolean, fullRefresh:boolean){
+    let defaultDataformCompileTime = getDataformCompilationTimeoutFromConfig();
+    let runmultitagscommand = getRunMultipleTagsCommand(workspaceFolder, selectedTags, defaultDataformCompileTime, includDependencies, includeDownstreamDependents, fullRefresh);
+    runCommandInTerminal(runmultitagscommand);
 }
 
 export async function  getMultipleFileSelection(workspaceFolder:string){

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -277,31 +277,40 @@ export async function getAllFilesWtAnExtension(workspaceFolder:string, extension
     return fileList;
 }
 
-export function getDataformActionCmdFromActionList(actionsList:string[], workspaceFolder:string, dataformCompilationTimeoutVal:string, includDependencies:boolean, includeDownstreamDependents:boolean, ){
+export function getDataformActionCmdFromActionList(actionsList:string[], workspaceFolder:string, dataformCompilationTimeoutVal:string, includDependencies:boolean, includeDownstreamDependents:boolean, fullRefresh:boolean){
         let dataformActionCmd = "";
         for (let i = 0; i < actionsList.length; i++) {
             let fullTableName = actionsList[i];
             if (i === 0) {
                 if (includDependencies) {
-                    dataformActionCmd = (`dataform run ${workspaceFolder} --timeout ${dataformCompilationTimeoutVal} --actions "${fullTableName}" --include-deps`);
+                    if (fullRefresh) {
+                        dataformActionCmd = (`dataform run ${workspaceFolder} --timeout ${dataformCompilationTimeoutVal} --actions "${fullTableName}" --include-deps --full-refresh`);
+                    } else {
+                        dataformActionCmd = (`dataform run ${workspaceFolder} --timeout ${dataformCompilationTimeoutVal} --actions "${fullTableName}" --include-deps`);
+                    }
                 } else if (includeDownstreamDependents) {
+                    if (fullRefresh) {
+                        dataformActionCmd = (`dataform run ${workspaceFolder} --timeout ${dataformCompilationTimeoutVal} --actions "${fullTableName}" --include-dependents --full-refresh`);
+                    } else {
                     dataformActionCmd = (`dataform run ${workspaceFolder} --timeout ${dataformCompilationTimeoutVal} --actions "${fullTableName}" --include-dependents`);
+                    }
                 }
                 else {
-                    dataformActionCmd = `dataform run ${workspaceFolder} --timeout ${dataformCompilationTimeoutVal} --actions "${fullTableName}"`;
+                    if (fullRefresh) {
+                        dataformActionCmd = (`dataform run ${workspaceFolder} --timeout ${dataformCompilationTimeoutVal} --actions "${fullTableName}" --full-refresh`);
+                    } else {
+                        dataformActionCmd = `dataform run ${workspaceFolder} --timeout ${dataformCompilationTimeoutVal} --actions "${fullTableName}"`;
+                    }
                 }
             } else {
-                if (includDependencies) {
-                    dataformActionCmd += ` --actions "${fullTableName}"`;
-                } else {
-                    dataformActionCmd += ` --actions "${fullTableName}"`;
-                }
+                // TODO: Not sure what is this doing ?
+                dataformActionCmd += ` --actions "${fullTableName}"`;
             }
         }
         return dataformActionCmd;
 }
 
-export async function runCurrentFile(includDependencies: boolean, includeDownstreamDependents: boolean) {
+export async function runCurrentFile(includDependencies: boolean, includeDownstreamDependents: boolean, fullRefresh: boolean) {
 
 
     let document = getVSCodeDocument();
@@ -332,7 +341,7 @@ export async function runCurrentFile(includDependencies: boolean, includeDownstr
         let dataformActionCmd = "";
 
         // create the dataform run command for the list of actions from actionsList
-        dataformActionCmd = getDataformActionCmdFromActionList(actionsList, workspaceFolder, dataformCompilationTimeoutVal, includDependencies, includeDownstreamDependents);
+        dataformActionCmd = getDataformActionCmdFromActionList(actionsList, workspaceFolder, dataformCompilationTimeoutVal, includDependencies, includeDownstreamDependents, fullRefresh);
         runCommandInTerminal(dataformActionCmd);
     }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -885,21 +885,22 @@ export async function formatSqlxFile(document:vscode.TextDocument, metadataForSq
     });
 }
 
-export async function runMultipleFiles(includDependencies: boolean, includeDownstreamDependents: boolean, fullRefresh: boolean){
-    let workspaceFolder = getWorkspaceFolder();
-    if (!workspaceFolder){
-        return;
-    }
-
-    let dataformCompiledJson = await runCompilation(workspaceFolder);
-
-    let tableMetadatas:any[] = [];
+export async function  getMultipleFileSelection(workspaceFolder:string){
     const fileList = await getAllFilesWtAnExtension(workspaceFolder, "sqlx");
     let options  = {
         canPickMany: true,
         ignoreFocusOut: true,
     };
     let selectedFiles = await vscode.window.showQuickPick(fileList, options);
+    return selectedFiles;
+}
+
+export async function runMultipleFilesFromSelection(workspaceFolder:string, selectedFiles:string, includDependencies:boolean, includeDownstreamDependents:boolean, fullRefresh:boolean){
+    let tableMetadatas:any[] = [];
+
+    let dataformCompiledJson = await runCompilation(workspaceFolder);
+    CACHED_COMPILED_DATAFORM_JSON = dataformCompiledJson;
+
     if (selectedFiles){
         for (let i = 0; i < selectedFiles.length; i ++){
             let relativeFilepath = selectedFiles[i];
@@ -908,6 +909,7 @@ export async function runMultipleFiles(includDependencies: boolean, includeDowns
             }
         }
     }
+
     let actionsList: string[] = [];
     tableMetadatas.forEach(tableMetadata => {
         if (tableMetadata) {
@@ -917,6 +919,7 @@ export async function runMultipleFiles(includDependencies: boolean, includeDowns
             });
         }
     });
+
     let dataformCompilationTimeoutVal = getDataformCompilationTimeoutFromConfig();
     let dataformActionCmd = "";
     dataformActionCmd = getDataformActionCmdFromActionList(actionsList, workspaceFolder, dataformCompilationTimeoutVal, includDependencies, includeDownstreamDependents, fullRefresh);


### PR DESCRIPTION
Solves: https://github.com/ashish10alex/vscode-dataform-tools/issues/20

1.  Introduce a command `Dataform: Run file(s) / tag(s) with options`  which opens the command pallets gives users option to 
2. Deprecate separate `Run multiple files` command and will be available as an option through (1) 



**Stage 1:** 

1. Run current file 
3. Run a tag
4. Run multiple files 
5. Run multiple tags

**Stage 2:**  Select weather to include dependencies or dependents 

**Stage 3:**  Select weather to do full refresh 

On clicking `Enter` after Stage 3 the command is generated and ran on the terminal 

![CleanShot 2024-09-22 at 11 20 45@2x](https://github.com/user-attachments/assets/3044c8d1-7519-4daf-9e0f-32c698227e72)




-------

#### TODO 

- [x] Test multi stage selection in command pallet 
- [x] Able to run a file with options 
- [x] Able to run a tag with options 
- [x] Run Multiple files with options 
- [x] Run multiple tags with options 
- [x] Create functions to abstract things where possible to reduce code 
- [x] Test to make sure nothing else is broken
