### PR TITLE
Additional table information on hover 

### DIFF
--- a/src/hoverProvider.ts
+++ b/src/hoverProvider.ts
@@ -5,10 +5,35 @@ import {
 } from "./utils";
 import { Assertion, DataformCompiledJson, Operation, Table } from "./types";
 
+function getTableInformationFromRef(
+  searchTerm: string,
+  struct: Table[]
+): vscode.Hover | undefined {
+  let hoverMeta: vscode.Hover | undefined;
+  for (let i = 0; i < struct.length; i++) {
+    let targetName = struct[i].target.name;
+    if (searchTerm === targetName) {
+
+      const content = `Table: ${struct[i].target.database}.${struct[i].target.schema}.${struct[i].target.name}` +
+                      `\nType: ${struct[i].type}` +
+                      (struct[i].bigquery?.partitionBy ? `\nPartition: ${struct[i].bigquery.partitionBy}` : ``) +
+                      (struct[i].dependencyTargets
+                        ? `\nDependencies:\n${struct[i].dependencyTargets
+                            .map(dep => `- ${dep.database}.${dep.schema}.${dep.name}`)
+                            .join('\n')}`
+                        : ``);
+      hoverMeta = new vscode.Hover({
+        language: "bash", // bash because it stands out for the format `gcp_project_id.dataset.table`
+        value: content,
+      });
+    }
+  }
+  return hoverMeta;
+}
 
 function getFullTableNameFromRef(
   searchTerm: string,
-  struct: Operation[] | Assertion[] | Table[]
+  struct: Operation[] | Assertion[]
 ): vscode.Hover | undefined {
   let hoverMeta: vscode.Hover | undefined;
   for (let i = 0; i < struct.length; i++) {
@@ -76,7 +101,7 @@ export class DataformHoverProvider implements vscode.HoverProvider {
       }
 
       if (tables) {
-        hoverMeta = getFullTableNameFromRef(searchTerm, tables);
+        hoverMeta = getTableInformationFromRef(searchTerm, tables);
       }
       if (hoverMeta) {
         return hoverMeta;

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ export interface Table {
     postOps: string[];
     incrementalPreOps: string[];
     dependencyTargets: Target[];
+    bigquery: TableBigQueryConfig;
 }
 
 export interface QueryMeta {
@@ -148,4 +149,10 @@ export interface GitHubContentResponse {
 export interface QueryWtType {
     query: string;
     type: string;
+}
+
+export interface TableBigQueryConfig {
+    partitionBy: string;
+    updatePartitionFilter: string;
+    clusterBy: string[];
 }


### PR DESCRIPTION
I think this is a nice feature to quickly see additional info on a referenced table. 
But please feel free to either just close or redo PR - first time with TS. 

This pull request introduces a new function to provide detailed hover information for tables in the `src/hoverProvider.ts` file and updates the `Table` interface in `src/types.ts` to include BigQuery configuration. The most important changes include the addition of the `getTableInformationFromRef` function and the modification of the `Table` interface.

### Enhancements to Hover Information:

* [`src/hoverProvider.ts`](diffhunk://#diff-07c4f16ecf031651eef822bcbfc4951045c0e47cb24ef35e1f0467145b1ce8a6R8-R36): Added `getTableInformationFromRef` function to provide detailed hover information, including the table's database, schema, type, partition, and dependencies.
* [`src/hoverProvider.ts`](diffhunk://#diff-07c4f16ecf031651eef822bcbfc4951045c0e47cb24ef35e1f0467145b1ce8a6L79-R104): Updated `DataformHoverProvider` to use the new `getTableInformationFromRef` function instead of `getFullTableNameFromRef`.

### Updates to Type Definitions:

* [`src/types.ts`](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aR14): Added `bigquery` property to the `Table` interface to include BigQuery-specific configurations.
* [`src/types.ts`](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aR153-R158): Defined a new `TableBigQueryConfig` interface to specify BigQuery configuration details such as partitioning and clustering.


Example:

![image](https://github.com/user-attachments/assets/3e0e68ba-8281-4134-9ce0-c8535db10b3f)
