### PR TITLE
feat: faster and improved compilation webview

### DIFF
--- a/media/css/query.css
+++ b/media/css/query.css
@@ -354,3 +354,17 @@
     max-height: 1000px; /* Adjust this value based on your expected content size */
     transition: max-height 0.5s ease-in;
 }
+
+#depsDiv ul, #depsDiv ol {
+  list-style-type: none; /* Remove default bullet */
+  padding: 0; /* Remove default padding */
+}
+
+#depsDiv li {
+  margin-bottom: 10px; /* Adjust this value to increase or decrease the gap */
+}
+
+/* Remove margin from the last item to avoid extra space at the bottom */
+#depsDiv li:last-child {
+  margin-bottom: 0;
+}

--- a/media/css/query.css
+++ b/media/css/query.css
@@ -347,12 +347,12 @@
 .dependency-list {
     max-height: 0;
     overflow: hidden;
-    transition: max-height 0.3s ease-out;
+    transition: max-height 0.1s ease-out;
 }
 
 .dependency-list.open {
     max-height: 1000px; /* Adjust this value based on your expected content size */
-    transition: max-height 0.5s ease-in;
+    transition: max-height 0.2s ease-in;
 }
 
 #depsDiv ul, #depsDiv ol {

--- a/media/js/showCompiledQuery.js
+++ b/media/js/showCompiledQuery.js
@@ -99,7 +99,7 @@ window.addEventListener('message', event => {
                     divElement.style.display = "none";
                 } else {
                     divElement.style.display = "";
-                    element.textContent = value;
+                    element.innerHTML = value;
                 }
             }
             else if (key === "dryRunStat"){

--- a/src/definitionProvider.ts
+++ b/src/definitionProvider.ts
@@ -48,7 +48,8 @@ export class DataformRefDefinitionProvider implements vscode.DefinitionProvider 
         let dataformCompiledJson: DataformCompiledJson | undefined;
         if (!CACHED_COMPILED_DATAFORM_JSON) {
             vscode.window.showWarningMessage('Compile the Dataform project once for faster go to definition');
-            dataformCompiledJson = await runCompilation(workspaceFolder);
+            let {dataformCompiledJson, error} = await runCompilation(workspaceFolder); // Takes ~1100ms
+            dataformCompiledJson = dataformCompiledJson;
         } else {
             dataformCompiledJson = CACHED_COMPILED_DATAFORM_JSON;
         }

--- a/src/definitionProvider.ts
+++ b/src/definitionProvider.ts
@@ -48,7 +48,7 @@ export class DataformRefDefinitionProvider implements vscode.DefinitionProvider 
         let dataformCompiledJson: DataformCompiledJson | undefined;
         if (!CACHED_COMPILED_DATAFORM_JSON) {
             vscode.window.showWarningMessage('Compile the Dataform project once for faster go to definition');
-            let {dataformCompiledJson, error} = await runCompilation(workspaceFolder); // Takes ~1100ms
+            let {dataformCompiledJson, errors} = await runCompilation(workspaceFolder); // Takes ~1100ms
             dataformCompiledJson = dataformCompiledJson;
         } else {
             dataformCompiledJson = CACHED_COMPILED_DATAFORM_JSON;

--- a/src/dependancyTree.ts
+++ b/src/dependancyTree.ts
@@ -87,7 +87,7 @@ export async function generateDependancyTreeMetadata(): Promise<{ dependancyTree
             return;
         }
 
-        let dataformCompiledJson = await runCompilation(workspaceFolder); // Takes ~1100ms
+        let {dataformCompiledJson, error} = await runCompilation(workspaceFolder); // Takes ~1100ms
         if (dataformCompiledJson) {
             CACHED_COMPILED_DATAFORM_JSON = dataformCompiledJson;
         }

--- a/src/dependancyTree.ts
+++ b/src/dependancyTree.ts
@@ -87,7 +87,7 @@ export async function generateDependancyTreeMetadata(): Promise<{ dependancyTree
             return;
         }
 
-        let {dataformCompiledJson, error} = await runCompilation(workspaceFolder); // Takes ~1100ms
+        let {dataformCompiledJson, errors} = await runCompilation(workspaceFolder); // Takes ~1100ms
         if (dataformCompiledJson) {
             CACHED_COMPILED_DATAFORM_JSON = dataformCompiledJson;
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -56,7 +56,7 @@ export async function activate(context: vscode.ExtensionContext) {
     let workspaceFolder = getWorkspaceFolder();
 
     if (workspaceFolder) {
-        let {dataformCompiledJson, error} = await runCompilation(workspaceFolder); // Takes ~1100ms
+        let {dataformCompiledJson, errors} = await runCompilation(workspaceFolder); // Takes ~1100ms
         if (dataformCompiledJson) {
             declarationsAndTargets = await getDependenciesAutoCompletionItems(dataformCompiledJson);
             dataformTags = await getDataformTags(dataformCompiledJson);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -56,9 +56,8 @@ export async function activate(context: vscode.ExtensionContext) {
     let workspaceFolder = getWorkspaceFolder();
 
     if (workspaceFolder) {
-        let dataformCompiledJson = await runCompilation(workspaceFolder);
+        let {dataformCompiledJson, error} = await runCompilation(workspaceFolder); // Takes ~1100ms
         if (dataformCompiledJson) {
-            CACHED_COMPILED_DATAFORM_JSON = dataformCompiledJson;
             declarationsAndTargets = await getDependenciesAutoCompletionItems(dataformCompiledJson);
             dataformTags = await getDataformTags(dataformCompiledJson);
         }
@@ -160,7 +159,11 @@ export async function activate(context: vscode.ExtensionContext) {
 
     context.subscriptions.push(
         vscode.commands.registerCommand('vscode-dataform-tools.showCompiledQueryWtDryRun', async () => {
-            CompiledQueryPanel.getInstance(context.extensionUri, context, true, true);
+            let currentFileMetadata = await getCurrentFileMetadata(true);
+            if (!currentFileMetadata?.isDataformWorkspace || !currentFileMetadata.fileMetadata) {
+                return;
+            }
+            CompiledQueryPanel.getInstance(context.extensionUri, context, true, true, currentFileMetadata);
         }));
 
     context.subscriptions.push(vscode.commands.registerCommand('vscode-dataform-tools.runTag', async () => {

--- a/src/hoverProvider.ts
+++ b/src/hoverProvider.ts
@@ -91,7 +91,8 @@ export class DataformHoverProvider implements vscode.HoverProvider {
       vscode.window.showWarningMessage(
         "Compile the Dataform project once for faster go to definition"
       );
-      dataformCompiledJson = await runCompilation(workspaceFolder);
+      let {dataformCompiledJson, error} = await runCompilation(workspaceFolder); // Takes ~1100ms
+      dataformCompiledJson = dataformCompiledJson;
     } else {
       dataformCompiledJson = CACHED_COMPILED_DATAFORM_JSON;
     }

--- a/src/hoverProvider.ts
+++ b/src/hoverProvider.ts
@@ -91,7 +91,7 @@ export class DataformHoverProvider implements vscode.HoverProvider {
       vscode.window.showWarningMessage(
         "Compile the Dataform project once for faster go to definition"
       );
-      let {dataformCompiledJson, error} = await runCompilation(workspaceFolder); // Takes ~1100ms
+      let {dataformCompiledJson, errors} = await runCompilation(workspaceFolder); // Takes ~1100ms
       dataformCompiledJson = dataformCompiledJson;
     } else {
       dataformCompiledJson = CACHED_COMPILED_DATAFORM_JSON;

--- a/src/runFiles.ts
+++ b/src/runFiles.ts
@@ -20,7 +20,7 @@ export async function runCurrentFile(includDependencies: boolean, includeDownstr
     }
 
     let currFileMetadata;
-    let dataformCompiledJson = await runCompilation(workspaceFolder);
+    let {dataformCompiledJson, error} = await runCompilation(workspaceFolder); // Takes ~1100ms
     if (dataformCompiledJson) {
         currFileMetadata = await getQueryMetaForCurrentFile(relativeFilePath, dataformCompiledJson);
     }

--- a/src/runFiles.ts
+++ b/src/runFiles.ts
@@ -20,7 +20,7 @@ export async function runCurrentFile(includDependencies: boolean, includeDownstr
     }
 
     let currFileMetadata;
-    let {dataformCompiledJson, error} = await runCompilation(workspaceFolder); // Takes ~1100ms
+    let {dataformCompiledJson, errors} = await runCompilation(workspaceFolder); // Takes ~1100ms
     if (dataformCompiledJson) {
         currFileMetadata = await getQueryMetaForCurrentFile(relativeFilePath, dataformCompiledJson);
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -156,3 +156,8 @@ export interface TableBigQueryConfig {
     updatePartitionFilter: string;
     clusterBy: string[];
 }
+
+export type GraphError = {
+  error: string;
+  fileName: string;
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -60,30 +60,36 @@ export async function getCurrentFileMetadata(freshCompilation: boolean) {
     if (!workspaceFolder) { return {isDataformWorkspace: false}; }
 
 
-    let dataformCompiledJson;
     if (freshCompilation || !CACHED_COMPILED_DATAFORM_JSON) {
-        dataformCompiledJson = await runCompilation(workspaceFolder); // Takes ~1100ms
-        if (dataformCompiledJson) {
-            CACHED_COMPILED_DATAFORM_JSON = dataformCompiledJson;
-        }
-    } else {
-        dataformCompiledJson = CACHED_COMPILED_DATAFORM_JSON;
-    }
+        let {dataformCompiledJson, error} = await runCompilation(workspaceFolder); // Takes ~1100ms
+            if(dataformCompiledJson){
+                let fileMetadata = await getQueryMetaForCurrentFile(relativeFilePath, dataformCompiledJson);
+                return {
+                    isDataformWorkspace: true,
+                    fileMetadata: fileMetadata,
+                    pathMeta: {
+                        filename: filename,
+                        extension: extension,
+                        relativeFilePath: relativeFilePath
+                    },
+                    document: document
+                };
+            }
+        } else {
+                let fileMetadata = await getQueryMetaForCurrentFile(relativeFilePath, CACHED_COMPILED_DATAFORM_JSON);
+                return {
+                    isDataformWorkspace: true,
+                    fileMetadata: fileMetadata,
+                    pathMeta: {
+                        filename: filename,
+                        extension: extension,
+                        relativeFilePath: relativeFilePath
+                    },
+                    document: document
+                };
 
-    if (dataformCompiledJson) {
-        let fileMetadata = await getQueryMetaForCurrentFile(relativeFilePath, dataformCompiledJson);
-        return {
-            isDataformWorkspace: true,
-            fileMetadata: fileMetadata,
-            pathMeta: {
-                filename: filename,
-                extension: extension,
-                relativeFilePath: relativeFilePath
-            },
-            document: document
-        };
-    }
-}
+        }
+    } 
 
 export async function getPostionOfSourceDeclaration(sourcesJsUri: vscode.Uri, searchTerm: string) {
     let sourcesDocument = await vscode.workspace.openTextDocument(sourcesJsUri);
@@ -127,7 +133,7 @@ export async function getTreeRootFromRef(): Promise<string | undefined> {
 
     if (!CACHED_COMPILED_DATAFORM_JSON) {
         vscode.window.showWarningMessage('Compile the Dataform project once for faster go to definition');
-        dataformCompiledJson = await runCompilation(workspaceFolder);
+        let {dataformCompiledJson, error} = await runCompilation(workspaceFolder);
         if (dataformCompiledJson) {
             CACHED_COMPILED_DATAFORM_JSON = dataformCompiledJson;
         }
@@ -602,14 +608,16 @@ function compileDataform(workspaceFolder: string): Promise<string> {
 }
 
 // Usage
-export async function runCompilation(workspaceFolder: string) {
+export async function runCompilation(workspaceFolder: string): Promise<{dataformCompiledJson:DataformCompiledJson|undefined, error:string}> {
     try {
+        console.log(`compilation called`);
         let compileResult = await compileDataform(workspaceFolder);
         const dataformCompiledJson: DataformCompiledJson = JSON.parse(compileResult);
         CACHED_COMPILED_DATAFORM_JSON = dataformCompiledJson;
-        return dataformCompiledJson;
-    } catch (error) {
-        vscode.window.showErrorMessage(`Error compiling Dataform: ${error}`);
+        return {dataformCompiledJson, error:""};
+    } catch (error:any) {
+        // vscode.window.showErrorMessage(`Error compiling Dataform: ${error}`);
+        return {dataformCompiledJson: undefined, error:error.message};
     }
 }
 
@@ -728,13 +736,12 @@ export async function runMultipleFilesFromSelection(workspaceFolder: string, sel
     let fileMetadatas: any[] = [];
 
     let dataformCompiledJson = await runCompilation(workspaceFolder);
-    CACHED_COMPILED_DATAFORM_JSON = dataformCompiledJson;
 
-    if (selectedFiles) {
+    if (selectedFiles && dataformCompiledJson.dataformCompiledJson !== undefined) {
         for (let i = 0; i < selectedFiles.length; i++) {
             let relativeFilepath = selectedFiles[i];
             if (dataformCompiledJson && relativeFilepath) {
-                fileMetadatas.push(await getQueryMetaForCurrentFile(relativeFilepath, dataformCompiledJson));
+                fileMetadatas.push(await getQueryMetaForCurrentFile(relativeFilepath, dataformCompiledJson.dataformCompiledJson));
             }
         }
     }
@@ -788,43 +795,6 @@ export async function gatherQueryAutoCompletionMeta(curFileMeta:any){
         declarationsAndTargets: declarationsAndTargets, dataformTags: dataformTags, currFileMetadata: currFileMetadata
     };
 
-}
-
-export function getQueryToDisplay(queryMeta:QueryMeta): string {
-    let concatenatedString = "";
-
-    if (queryMeta.tableOrViewQuery && queryMeta.tableOrViewQuery !== "") {
-        concatenatedString += "----------\n -- Query\n ----------\n" + queryMeta.tableOrViewQuery + "\n\n";
-    }
-
-    if (queryMeta.assertionQuery && queryMeta.assertionQuery !== "") {
-        concatenatedString += "----------\n -- Assertion\n ----------\n" + queryMeta.assertionQuery + "\n\n";
-    }
-
-    if (queryMeta.preOpsQuery && queryMeta.preOpsQuery !== "") {
-        concatenatedString += "----------\n -- Pre Operation\n ----------\n" + queryMeta.preOpsQuery + "\n\n";
-    }
-
-    if (queryMeta.postOpsQuery && queryMeta.postOpsQuery !== "") {
-        concatenatedString += "----------\n -- Post Operation\n ----------\n" + queryMeta.postOpsQuery + "\n\n";
-    }
-
-    if (queryMeta.incrementalPreOpsQuery && queryMeta.incrementalPreOpsQuery !== "") {
-        concatenatedString += "----------\n -- Incremental Pre Operation\n ----------\n" + queryMeta.incrementalPreOpsQuery + "\n\n";
-    }
-
-    if (queryMeta.incrementalQuery && queryMeta.incrementalQuery !== "") {
-        concatenatedString += "----------\n -- Incremental Query\n ----------\n" + queryMeta.incrementalQuery + "\n\n";
-    }
-
-    if (queryMeta.nonIncrementalQuery && queryMeta.nonIncrementalQuery !== "") {
-        concatenatedString += "----------\n -- Non Incremental Query\n ----------\n" + queryMeta.nonIncrementalQuery + "\n\n";
-    }
-
-    if (queryMeta.operationsQuery && queryMeta.operationsQuery !== "") {
-        concatenatedString += "----------\n -- Operations Query\n ----------\n" + queryMeta.operationsQuery + "\n\n";
-    }
-    return concatenatedString;
 }
 
 export async function dryRunAndShowDiagnostics(curFileMeta:any, queryAutoCompMeta:any, document:vscode.TextDocument, diagnosticCollection:any, showCompiledQueryInVerticalSplitOnSave:boolean|undefined){

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -77,32 +77,31 @@ export async function getCurrentFileMetadata(freshCompilation: boolean) {
                 };
             }
         else if (errors?.length!==0){
-                return {
-                    isDataformWorkspace: true,
-                    dataformCompilationErrors:errors,
-                    fileMetadata: undefined,
-                    pathMeta: {
-                        filename: filename,
-                        extension: extension,
-                        relativeFilePath: relativeFilePath
-                    },
-                    document: document
-                };
-
+            CACHED_COMPILED_DATAFORM_JSON = undefined;
+            return {
+                isDataformWorkspace: true,
+                dataformCompilationErrors:errors,
+                fileMetadata: undefined,
+                pathMeta: {
+                    filename: filename,
+                    extension: extension,
+                    relativeFilePath: relativeFilePath
+                },
+                document: document
+            };
         }
         } else {
-                let fileMetadata = await getQueryMetaForCurrentFile(relativeFilePath, CACHED_COMPILED_DATAFORM_JSON);
-                return {
-                    isDataformWorkspace: true,
-                    fileMetadata: fileMetadata,
-                    pathMeta: {
-                        filename: filename,
-                        extension: extension,
-                        relativeFilePath: relativeFilePath
-                    },
-                    document: document
-                };
-
+            let fileMetadata = await getQueryMetaForCurrentFile(relativeFilePath, CACHED_COMPILED_DATAFORM_JSON);
+            return {
+                isDataformWorkspace: true,
+                fileMetadata: fileMetadata,
+                pathMeta: {
+                    filename: filename,
+                    extension: extension,
+                    relativeFilePath: relativeFilePath
+                },
+                document: document
+            };
         }
     } 
 

--- a/src/views/register-preview-compiled-panel.ts
+++ b/src/views/register-preview-compiled-panel.ts
@@ -80,7 +80,8 @@ export class CompiledQueryPanel {
                 return;
             }
 
-            if (!currentFileMetadata?.isDataformWorkspace || !currentFileMetadata.fileMetadata) {
+            //TODO: Handle this later
+            if (!currentFileMetadata?.isDataformWorkspace) {
                 return;
             }
 
@@ -111,6 +112,20 @@ export class CompiledQueryPanel {
         const webview = this.webviewPanel.webview;
         if (this.webviewPanel.webview.html === ""){
             this.webviewPanel.webview.html = this._getHtmlForWebview(webview);
+        }
+
+        if (curFileMeta.isDataformWorkspace===false){
+            return;
+        }
+        
+        if(curFileMeta.dataformCompilationErrors){
+            let errorString = "<p>Error compiling Dataform:</p><ul>" + curFileMeta.dataformCompilationErrors.map((error:string) => `<li>${error}</li>`).join('') + "</ul>";
+            errorString += "Run `dataform compile` to see more details";
+
+            await webview.postMessage({
+                "errorMessage": errorString
+            });
+            return;
         }
 
         let fileMetadata = handleSemicolonPrePostOps(curFileMeta.fileMetadata);


### PR DESCRIPTION
This PR 


**Compilation webview**
- [x] Show compilation errors in webview 
- [x] Mark files with errors from `dataform compile` metadata with the graph errors they have
- [x] Removes compiling twice when generating compiled query web view  

**Cleanup** 

- [x] Removes `getQueryToDisplay` no longer needed as we are no longer displaying the compiled query as sql file in split
- [x] Increase space between list items in dependencies to make them easier to read
- [x] Test to ensure nothing else is broken 

Screenshot of how a compilation error will show on webview 

![CleanShot 2024-11-12 at 12 06 34@2x](https://github.com/user-attachments/assets/58a71c26-ffc4-4f0e-86e6-4fc686ceabf9)
