### PR TITLE
feat: simplify go to definition for js variables 

### DIFF
--- a/src/definitionProvider.ts
+++ b/src/definitionProvider.ts
@@ -250,11 +250,11 @@ export class DataformJsDefinitionProvider implements vscode.DefinitionProvider {
 
             } else if (content.includes(".")){
                 const [jsFileName, variableOrFunctionName] = content.split('.'); 
-                console.log(`jsFileName: ${jsFileName}, variableOrfunctionName: ${variableOrFunctionName}`);
+                // console.log(`jsFileName: ${jsFileName}, variableOrfunctionName: ${variableOrFunctionName}`);
                 return findModuleVarDefinition(document, workspaceFolder, jsFileName, variableOrFunctionName);
 
             } else if (content.includes('.') === false && content.trim() !== ''){
-                console.log(`variableOrfunctionName: ${content}`);
+                // console.log(`variableOrfunctionName: ${content}`);
                 const sqlxFileMetadata = getMetadataForSqlxFileBlocks(document);
                 const jsBlock = sqlxFileMetadata.jsBlock;
                 if(jsBlock.exists === true){

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,7 +5,7 @@ import { registerWebViewProvider } from './views/register-sidebar-panel';
 import { CustomViewProvider } from './views/register-query-results-panel';
 import { registerCenterPanel } from './views/register-center-panel';
 import { dataformCodeActionProviderDisposable, applyCodeActionUsingDiagnosticMessage } from './codeActionProvider';
-import { DataformRefDefinitionProvider, DataformRequireDefinitionProvider, DataformJsDefinitionProvider } from './definitionProvider';
+import { DataformRequireDefinitionProvider, DataformJsDefinitionProvider } from './definitionProvider';
 import { DataformHoverProvider } from './hoverProvider';
 import { executablesToCheck } from './constants';
 import { getWorkspaceFolder, getDependenciesAutoCompletionItems, getDataformTags, getCurrentFileMetadata } from './utils';
@@ -110,10 +110,6 @@ export async function activate(context: vscode.ExtensionContext) {
         })
     );
 
-    context.subscriptions.push(vscode.languages.registerDefinitionProvider(
-        { language: 'sqlx' },
-        new DataformRefDefinitionProvider()
-    ));
     context.subscriptions.push(vscode.languages.registerDefinitionProvider(
         { language: 'sqlx' },
         new DataformRequireDefinitionProvider()

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -118,12 +118,33 @@ export async function getPostionOfSourceDeclaration(sourcesJsUri: vscode.Uri, se
         if (wordIndex !== -1) {
             line = lineNum;
             character = wordIndex;
+            return new vscode.Position(line, character);
         }
     }
     if (line === null || character === null) {
         return undefined;
     }
-    return new vscode.Position(line, character);
+}
+
+export async function getPostionOfVariableInJsBlock(document:vscode.TextDocument, searchTerm:string, jsBlockStartLine:number, jsBlockEndLine:number) {
+    let sourcesDocument = await vscode.workspace.openTextDocument(document.uri);
+
+    let line = null;
+    let character = null;
+
+    for (let lineNum = jsBlockStartLine; lineNum < jsBlockEndLine; lineNum++) {
+        const lineText = sourcesDocument.lineAt(lineNum).text;
+        const wordIndex = lineText.indexOf(searchTerm);
+
+        if (wordIndex !== -1) {
+            line = lineNum;
+            character = wordIndex;
+            return new vscode.Position(line, character);
+        }
+    }
+    if (line === null || character === null) {
+        return undefined;
+    }
 }
 
 export async function getTreeRootFromRef(): Promise<string | undefined> {


### PR DESCRIPTION
This PR:

- [x] Avoids the need for multiple definition providers. In the current implementation in https://github.com/ashish10alex/vscode-dataform-tools/pull/51 two go to definitions are invoked simultaneously 
- [x] Adds support for go to definition when the variables are defined in  a js block inside the sqlx file 
- [x] Dumbs down the matching process. Find the file -> Find the search term in the file.  We will need to change this. But I want to find appropriate test cases where it might be false to add a more non-trivial regex / function.  

Test case where the above implementation works 

```js
config {
  type: 'table'
}

/*
create a parameters.js file in the includes directory and add 
getDateMonthsBefore function

function getDateMonthsBefore(date, months) {
  date.setMonth(date.getMonth() + months);
  let date_string = date.toISOString().split('T')[0];
  date_string = `'${date_string}'`;
  return date_string

}
*/

js {
  const six_months_ago_from_now = parameters.getDateMonthsBefore(new Date(), -6)
  const four_months_ago_from_now = parameters.getDateMonthsBefore(new Date(), -6)
  const some_month = "january"
  const some_number = 11;
  let some_coniditon = true;
  let another_coniditon = true;
  var some_floating_points = 9.4;
}

select 
  *
, ${six_months_ago_from_now} as some_time
, ${four_months_ago_from_now} as some_time
, ${some_number} as some_number
, ${some_coniditon} as some_condition
, ${another_coniditon} as another_coniditon
, ${some_floating_points} as some_floating_points
, "${some_month}" as some_month 
, ${parameters.OXRC_DATA_STARTING_POINT}
FROM ${ref("0100_CALENDAR")}


```


**Assumptions of the implementation** (generous*)

1. If go to def is triggered from `${some_text}` it assumes some_text is variable defined in either a `.js` file in `includes` directory or in `js` block in the same sqlx file 
2.If go to def is triggered from `${some_text.other_text`} it assumes `some_text` is the file name and `other_text` is the variable name that exsists in the `.js` file
3. Once we parse out file name and variable name from (2) we use that and search for the 1st occurrence of it. This part needs work as you have suggested in your original MR. As I guess this can be a function too and there might be multiple declarations or use of that word in the js file. 