### PR TITLE
feat:  make finding the position of js variable / functions more robust

### DIFF
--- a/src/definitionProvider.ts
+++ b/src/definitionProvider.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { getPostionOfSourceDeclaration, getPostionOfVariableInJsBlock, getWorkspaceFolder, runCompilation } from './utils';
+import { getPostionOfSourceDeclaration, getPostionOfVariableInJsFileOrBlock, getWorkspaceFolder, runCompilation } from './utils';
 import { Assertion, DataformCompiledJson, Operation, Table } from './types';
 import path from 'path';
 import * as fs from 'fs';
@@ -176,7 +176,7 @@ async function findModuleVarDefinition(
             if(fileName === jsFileName + ".js"){
                 const filePath = path.join(includesPath, fileName);
                 const filePathUri = vscode.Uri.file(filePath);
-                const position = await getPostionOfSourceDeclaration(filePathUri, variableName);
+                const position = await getPostionOfVariableInJsFileOrBlock(filePathUri, variableName, 0, -1);
                 if (position){
                     return new vscode.Location(filePathUri, position);
                 };
@@ -191,13 +191,28 @@ async function findModuleVarDefinition(
     if (importedModule) {
         const filePath = path.join(workspaceFolder, importedModule.path);
         const filePathUri = vscode.Uri.file(filePath);
-        const position = await getPostionOfSourceDeclaration(filePathUri, variableName);
+        const position = await getPostionOfVariableInJsFileOrBlock(filePathUri, variableName, 0, -1);
         if (position){
             return new vscode.Location(filePathUri, position);
         };
     }
 
     return undefined;
+}
+
+/**
+ * Extracts the function name from a function call string.
+ * 
+ * @example
+ * extractFunctionName("getDate()"); // Returns "getDate"
+ * extractFunctionName("object.method(arg1, arg2)"); // Returns "method"
+ * extractFunctionName("namespace.subnamespace.func()"); // Returns "func"
+ * extractFunctionName("someVariable"); // Returns null //
+ */
+function extractFunctionName(functionString:string) {
+  const regex = /(?:^|\.)(\w+)\(/;
+  const match = functionString.match(regex);
+  return match ? match[1] : null;
 }
 
 
@@ -261,15 +276,20 @@ export class DataformJsDefinitionProvider implements vscode.DefinitionProvider {
             if (content.includes("ref(")  || content.includes("resolve(")) {
                 return getLocationForRefsAndResolve(document, searchTerm);
             } else if (content.includes(".")){
-                const [jsFileName, variableOrFunctionName] = content.split('.'); 
+                const [jsFileName, variableOrFunctionSignature] = content.split('.'); 
+                const variableOrFunctionName = extractFunctionName(variableOrFunctionSignature);
                 // console.log(`jsFileName: ${jsFileName}, variableOrfunctionName: ${variableOrFunctionName}`);
-                return findModuleVarDefinition(document, workspaceFolder, jsFileName, searchTerm);
+                if(variableOrFunctionName !== null){
+                    return findModuleVarDefinition(document, workspaceFolder, jsFileName, variableOrFunctionName);
+                } else{
+                    return findModuleVarDefinition(document, workspaceFolder, jsFileName, variableOrFunctionSignature);
+                }
             } else if (content.includes('.') === false && content.trim() !== ''){
                 // console.log(`variableOrfunctionName: ${content}`);
                 const sqlxFileMetadata = getMetadataForSqlxFileBlocks(document);
                 const jsBlock = sqlxFileMetadata.jsBlock;
                 if(jsBlock.exists === true){
-                    const position = await getPostionOfVariableInJsBlock(document, searchTerm, jsBlock.startLine, jsBlock.endLine);
+                    const position = await getPostionOfVariableInJsFileOrBlock(document, searchTerm, jsBlock.startLine, jsBlock.endLine);
                     if(position){
                         return new vscode.Location(document.uri, position);
                     }

--- a/src/definitionProvider.ts
+++ b/src/definitionProvider.ts
@@ -271,7 +271,7 @@ export class DataformJsDefinitionProvider implements vscode.DefinitionProvider {
         const regex = /\$\{([^}]+)\}/g;
         let match;
         while ((match = regex.exec(line)) !== null) {
-            console.log(`Found reference: ${match[0]}, Content: ${match[1]}`);
+            // console.log(`Found reference: ${match[0]}, Content: ${match[1]}`);
             const content =  (match[1]);
             if (content.includes("ref(")  || content.includes("resolve(")) {
                 return getLocationForRefsAndResolve(document, searchTerm);


### PR DESCRIPTION
This PR 

related to https://github.com/ashish10alex/vscode-dataform-tools/pull/51

- [x] Improves robustness of finding variable / function when using go to definition 
- [x] Single function to get variable or function from js file / block 

Tested against following input .Updated with scenarios which would have previously failed

```js
config {
  type: 'table'
}

/*
create a parameters.js file in the includes directory and add 
getDateMonthsBefore function

function getDateMonthsBefore(date, months) {
  date.setMonth(date.getMonth() + months);
  let date_string = date.toISOString().split('T')[0];
  date_string = `'${date_string}'`;
  return date_string

}
*/

js {
  let some_mod = require("includes/parameters.js")
  const team = "barcelona"
  const six_months_ago_from_now = some_mod.getDateMonthsBefore(new Date(), -6)
  const four_months_ago_from_now = some_mod.getDateMonthsBefore(new Date(), -6)
  const some_month = "january"
  const some_number = 11;
  const barcelona = "a team"
  let some_coniditon = true;
  let another_coniditon = true;
  var some_floating_points = 9.4;
}

select 
  *
, ${six_months_ago_from_now}  some_time_1
, ${four_months_ago_from_now}  some_time_2
, ${some_number}  some_number
, ${some_coniditon}  some_condition
, ${another_coniditon}  another_coniditon
, ${some_floating_points}  some_floating_points
, "${some_month}"  some_month 
, ${some_mod.getDateMonthsBefore(new Date(), -4)} date_wt_func
, ${parameters.OXRC_DATA_STARTING_POINT}  as date_from_file
, "${barcelona}" as some_team
FROM ${ref("0100_CALENDAR")}
```