### PR TITLE
feat: add bq link to preview query view

### DIFF
--- a/media/js/showQueryResults.js
+++ b/media/js/showQueryResults.js
@@ -88,6 +88,18 @@ function updateDateTime(elapsedTime, totalGbBilled) {
     document.getElementById('datetime').textContent = "Query results ran at: " + queryStatsText;
 }
 
+function updateBigQueryJobLink(bigQueryJobId) {
+    const bigQueryJobLink = document.getElementById('bigQueryJobLink');
+    const bigQueryJobLinkDivider = document.getElementById('bigQueryJobLinkDivider');
+    const projectId = bigQueryJobId.split(':')[0];
+    const jobId = bigQueryJobId.split(':')[1].replace('.', ':');
+    const bigQueryLink = `https://console.cloud.google.com/bigquery?project=${projectId}&j=bq:${jobId}&page=queryresults`;
+
+    bigQueryJobLinkDivider.textContent = ' | '; 
+    bigQueryJobLink.href = bigQueryLink;
+    bigQueryJobLink.textContent = `View in BigQuery`;
+}
+
 // Hide the table initially
 const bigQueryResults = document.getElementById('bigqueryResults');
 if (bigQueryResults){
@@ -113,6 +125,7 @@ window.addEventListener('message', event => {
     const jobStats = event?.data?.jobStats;
     const noResults = event?.data?.noResults;
     const totalBytesBilled = jobStats?.totalBytesBilled;
+    const jobId = jobStats?.jobId;
     const bigQueryJobId = event?.data?.bigQueryJobId;
     const bigQueryJobCancelled = event?.data?.bigQueryJobCancelled;
     const errorMessage = event?.data?.errorMessage;
@@ -134,6 +147,7 @@ window.addEventListener('message', event => {
         document.getElementById("runQueryButton").disabled = false;
         document.getElementById("cancelBigQueryJobButton").disabled = true;
         updateDateTime(elapsedTime, totalGbBilled);
+        updateBigQueryJobLink(jobId);
         clearInterval(timerInterval);
         if (loadingMessage){
             document.body.removeChild(loadingMessage);

--- a/src/bigqueryRunQuery.ts
+++ b/src/bigqueryRunQuery.ts
@@ -151,10 +151,12 @@ export async function queryBigQuery(query: string) {
     queryLimit = 1000;
 
     let totalBytesBilled;
+    let jobId;
 
     if (bigQueryJob) {
         let jobMetadata = await bigQueryJob.getMetadata();
         let jobStats = jobMetadata[0].statistics.query;
+        jobId = jobMetadata[0].id;
         totalBytesBilled = jobStats.totalBytesBilled;
         bigQueryJob = undefined;
     }
@@ -212,7 +214,7 @@ export async function queryBigQuery(query: string) {
 
     let columns = createTabulatorColumns(results[0]);
 
-    return { results: results, columns: columns, jobStats: { totalBytesBilled: totalBytesBilled } };
+    return { results: results, columns: columns, jobStats: { totalBytesBilled: totalBytesBilled, jobId: jobId} };
 }
 
 export async function cancelBigQueryJob() {

--- a/src/views/register-query-results-panel.ts
+++ b/src/views/register-query-results-panel.ts
@@ -171,7 +171,11 @@ export class CustomViewProvider implements vscode.WebviewViewProvider {
       <button id="runQueryButton" class="runQueryButton">RUN</button>
       <button id="cancelBigQueryJobButton" class="cancelBigQueryJobButton">Cancel query</button>
 
-      <p><span id="datetime"></span></p>
+      <p>
+      <span id="datetime"></span>
+      <span id="bigQueryJobLinkDivider"></span>
+      <a id="bigQueryJobLink" href="" target="_blank"></a>
+      </p>
 
       <div class="error-message-container" id="errorsDiv" style="display: none;" >
           <p><span id="errorMessage"></span></p>


### PR DESCRIPTION
Here’s a well-formatted version of your GitHub pull request description:

---

# Add Feature to View a Preview Query Job in the BigQuery Console

This PR introduces a feature that allows users to view a preview query job directly in the BigQuery console.  
![Preview Image](https://github.com/user-attachments/assets/b079f846-9201-4d13-b4a5-56caecf011b1)

### What’s New
- Clicking the link takes the user to the corresponding query job in BigQuery.
- This eliminates the need to manually copy the compiled query for ad-hoc testing in BigQuery.

### Need Help Testing
- I’d appreciate help verifying that the method I use to parse the `bigQueryJobId` into a functional link works for others, as it currently works for me.

_The user needs to have BQ Job List permission in GCP to be able to use the link._

There might be a better way to fetch the job ID, as we currently use two similar variables inside of the window event listener (`jobId` and `bigQueryJobId`). This could potentially lead to confusion.