### PR TITLE
chore: consistent variable names for bigQuery job id

### DIFF
--- a/media/js/showQueryResults.js
+++ b/media/js/showQueryResults.js
@@ -97,7 +97,7 @@ function updateBigQueryJobLink(bigQueryJobId) {
 
     bigQueryJobLinkDivider.textContent = ' | '; 
     bigQueryJobLink.href = bigQueryLink;
-    bigQueryJobLink.textContent = `View in BigQuery`;
+    bigQueryJobLink.textContent = `View job in BigQuery`;
 }
 
 // Hide the table initially
@@ -125,8 +125,7 @@ window.addEventListener('message', event => {
     const jobStats = event?.data?.jobStats;
     const noResults = event?.data?.noResults;
     const totalBytesBilled = jobStats?.totalBytesBilled;
-    const jobId = jobStats?.jobId;
-    const bigQueryJobId = event?.data?.bigQueryJobId;
+    const bigQueryJobId = jobStats?.bigQueryJobId || event?.data?.bigQueryJobId;
     const bigQueryJobCancelled = event?.data?.bigQueryJobCancelled;
     const errorMessage = event?.data?.errorMessage;
     const query = event?.data?.query;
@@ -147,7 +146,7 @@ window.addEventListener('message', event => {
         document.getElementById("runQueryButton").disabled = false;
         document.getElementById("cancelBigQueryJobButton").disabled = true;
         updateDateTime(elapsedTime, totalGbBilled);
-        updateBigQueryJobLink(jobId);
+        updateBigQueryJobLink(bigQueryJobId);
         clearInterval(timerInterval);
         if (loadingMessage){
             document.body.removeChild(loadingMessage);
@@ -182,7 +181,7 @@ window.addEventListener('message', event => {
         postRunCleanup();
         const jobCancelled = document.querySelector('.bigquery-job-cancelled');
         if(jobCancelled){
-            jobCancelled.textContent = `❕ BigQuery Job was cancelled, jobId: ${bigQueryJobId}`;
+            jobCancelled.textContent = `❕ BigQuery Job was cancelled, bigQueryJobId: ${bigQueryJobId}`;
         }
     }
 

--- a/src/bigqueryRunQuery.ts
+++ b/src/bigqueryRunQuery.ts
@@ -151,12 +151,12 @@ export async function queryBigQuery(query: string) {
     queryLimit = 1000;
 
     let totalBytesBilled;
-    let jobId;
+    let bigQueryJobId;
 
     if (bigQueryJob) {
         let jobMetadata = await bigQueryJob.getMetadata();
         let jobStats = jobMetadata[0].statistics.query;
-        jobId = jobMetadata[0].id;
+        bigQueryJobId = jobMetadata[0].id;
         totalBytesBilled = jobStats.totalBytesBilled;
         bigQueryJob = undefined;
     }
@@ -214,7 +214,7 @@ export async function queryBigQuery(query: string) {
 
     let columns = createTabulatorColumns(results[0]);
 
-    return { results: results, columns: columns, jobStats: { totalBytesBilled: totalBytesBilled, jobId: jobId} };
+    return { results: results, columns: columns, jobStats: { totalBytesBilled: totalBytesBilled, bigQueryJobId: bigQueryJobId} };
 }
 
 export async function cancelBigQueryJob() {
@@ -229,6 +229,7 @@ export async function cancelBigQueryJob() {
         vscode.window.showInformationMessage(`Cancelled BigQuery job with id ${bigQueryJobId}`);
         return { cancelled: true, bigQueryJobId: bigQueryJobId };
     } else {
+        vscode.window.showInformationMessage(`Was unable to cancel job, please check for your job in BigQuery console`);
         return { cancelled: undefined, bigQueryJobId: undefined };
     }
 }


### PR DESCRIPTION
This PR:

related to https://github.com/ashish10alex/vscode-dataform-tools/pull/62

ensure that single variable `bigQueryJobId` is used to identify bigquery job id 