### PR TITLE
feat: trigger table run & data preview directly from compiled web ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 | [Inline diagnostics on `.sqlx` file](#diagnostics) ❗ | Native lsp like experience with diagnostics being directly put on both the sqlx file & compiled query |
 | [Preview query results](#preview_query_results) | Preview query results in a table by running the file |
 | [Go to definition](#definition) | Go to definition for source in `$ref{("my_source")}` and javascript blocks in `.sqlx` files  |
-| [Auto-completion](#autocomplete) | - Column names of current model dependencies and declarations in `${ref("..")}` trigger when `$` character is typed <br><br> - Dependencies when `"` or `'` is typed inside the config block which has `dependencies` keyword is in the line prefix <br><br> - `tags` when `"` or `'` is typed inside the config block which has `tags` keyword is in the line prefix |
+| [Auto-completion](#autocomplete) | - Column names of current model <br><br> - Dependencies and declarations in `${ref("..")}` trigger when `$` character is typed <br><br> - Dependencies when `"` or `'` is typed inside the config block which has `dependencies` keyword is in the line prefix <br><br> - `tags` when `"` or `'` is typed inside the config block which has `tags` keyword is in the line prefix |
 | [Code actions](#codeactions) | Apply dry run suggestions at the speed of thought |
 | [Run file(s)/tag(s)](#filetagruns) | Run file(s)/tag(s), optionally with dependencies/dependents/full refresh using vscode command pallet / menu icons |
 | [Format using Sqlfluff](#formatting) 🪄 | Fromat `.sqlx` files using [sqlfluff](https://github.com/sqlfluff/sqlfluff)|
@@ -31,7 +31,10 @@
 
 1. [Dataform cli](https://cloud.google.com/dataform/docs/use-dataform-cli)
 
-   `npm i -g @dataform/cli`
+   ```bash
+   # requires nodejs
+   npm i -g @dataform/cli
+   ```
 
    Run `dataform compile` from the root of your Dataform project to ensure that you are able to use the cli
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Open vscode command pallet by pressing <kbd>CTLR</kbd> + <kbd>SHIFT</kbd> + <kbd
 ## Known Issues
 
 - [ ] Features such as go to definition / dependancy graph might not work with consistantly with `${ref("dataset", "table")}` or when it is multiline or a different format works best with `${ref('table_name')}` format
+- [ ] If a model returns more than ~2 million rows the BigQuery api does not seem to return any results
 
 ## TODO
 

--- a/media/css/query.css
+++ b/media/css/query.css
@@ -1,3 +1,14 @@
+button:disabled {
+   background-color: #cccccc;
+   color: #666666;
+   cursor: not-allowed;
+   opacity: 0.7;
+}
+
+button:disabled:hover {
+   background-color: #cccccc;
+}
+
 #runQueryButton {
 	position: absolute;
 	top: 6px;
@@ -401,7 +412,6 @@
 .run-model:hover {
   background-color: #3291d0;
 }
-
 
 .model-checkbox-container {
     display: inline-flex;

--- a/media/css/query.css
+++ b/media/css/query.css
@@ -387,3 +387,25 @@
     margin-left: 6px;
     vertical-align: middle;
   }
+
+.run-model {
+	background-color: #007acc;
+	color: #ffffff;
+	padding: 5px 10px;
+	font-size: 16px;
+	border-radius: 5px;
+	border: none;
+	cursor: pointer;
+}
+
+.run-model:hover {
+  background-color: #3291d0;
+}
+
+
+.model-checkbox-container {
+    display: inline-flex;
+    align-items: center;
+    cursor: pointer;
+    margin: 10px;
+}

--- a/media/js/showCompiledQuery.js
+++ b/media/js/showCompiledQuery.js
@@ -10,6 +10,7 @@ const runModelButton = document.getElementById('runModel');
 const includeDependenciesCheckbox = document.getElementById('includeDependencies');
 const includeDependentsCheckBox = document.getElementById('includeDependents');
 function runModelClickHandler() {
+    runModelButton.disabled = true;
     vscode.postMessage({
         command: 'runModel',
         value: {
@@ -18,6 +19,10 @@ function runModelClickHandler() {
             includeDependencies: includeDependenciesCheckbox.checked,
         }
     });
+
+    setTimeout(() => {
+        runModelButton.disabled = false;
+    }, 10000);
 }
 
 if (runModelButton) {

--- a/media/js/showCompiledQuery.js
+++ b/media/js/showCompiledQuery.js
@@ -9,6 +9,7 @@ document.addEventListener('DOMContentLoaded', () => {
 const runModelButton = document.getElementById('runModel');
 const includeDependenciesCheckbox = document.getElementById('includeDependencies');
 const includeDependentsCheckBox = document.getElementById('includeDependents');
+const fullRefreshCheckBox = document.getElementById('fullRefresh');
 
 function runModelClickHandler() {
     runModelButton.disabled = true;
@@ -18,6 +19,7 @@ function runModelClickHandler() {
             runMode: true,
             includeDependents: includeDependentsCheckBox.checked,
             includeDependencies: includeDependenciesCheckbox.checked,
+            fullRefresh: fullRefreshCheckBox.checked,
         }
     });
 

--- a/media/js/showCompiledQuery.js
+++ b/media/js/showCompiledQuery.js
@@ -6,6 +6,25 @@ document.addEventListener('DOMContentLoaded', () => {
     }));
 });
 
+const runModelButton = document.getElementById('runModel');
+const includeDependenciesCheckbox = document.getElementById('includeDependencies');
+const includeDependentsCheckBox = document.getElementById('includeDependents');
+function runModelClickHandler() {
+    vscode.postMessage({
+        command: 'runModel',
+        value: {
+            runMode: true,
+            includeDependents: includeDependentsCheckBox.checked,
+            includeDependencies: includeDependenciesCheckbox.checked,
+        }
+    });
+}
+
+if (runModelButton) {
+    runModelButton.addEventListener('click', runModelClickHandler);
+}
+
+
 const depsDiv = document.getElementById("depsDiv");
 const dependencyHeader = document.querySelector('.dependency-header');
 const arrowToggle = document.querySelector('.arrow-toggle');

--- a/media/js/showCompiledQuery.js
+++ b/media/js/showCompiledQuery.js
@@ -9,6 +9,7 @@ document.addEventListener('DOMContentLoaded', () => {
 const runModelButton = document.getElementById('runModel');
 const includeDependenciesCheckbox = document.getElementById('includeDependencies');
 const includeDependentsCheckBox = document.getElementById('includeDependents');
+
 function runModelClickHandler() {
     runModelButton.disabled = true;
     vscode.postMessage({
@@ -27,6 +28,18 @@ function runModelClickHandler() {
 
 if (runModelButton) {
     runModelButton.addEventListener('click', runModelClickHandler);
+}
+
+const previewResultsButton = document.getElementById('previewResults');
+function previewResultsClickHandler() {
+    vscode.postMessage({
+        command: 'previewResults',
+        value: true
+    });
+}
+
+if (previewResults) {
+    previewResultsButton.addEventListener('click', previewResultsClickHandler);
 }
 
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,7 +9,7 @@ import { dataformCodeActionProviderDisposable, applyCodeActionUsingDiagnosticMes
 import { DataformRequireDefinitionProvider, DataformJsDefinitionProvider } from './definitionProvider';
 import { DataformHoverProvider } from './hoverProvider';
 import { executablesToCheck } from './constants';
-import { getWorkspaceFolder, getDependenciesAutoCompletionItems, getDataformTags, getCurrentFileMetadata, sendNotifactionToUserOnExtensionUpdate } from './utils';
+import { getWorkspaceFolder, getDependenciesAutoCompletionItems, getDataformTags, getCurrentFileMetadata, sendNotifactionToUserOnExtensionUpdate, getVSCodeDocument } from './utils';
 import { executableIsAvailable, runCompilation } from './utils';
 import { sourcesAutoCompletionDisposable, dependenciesAutoCompletionDisposable, tagsAutoCompletionDisposable, schemaAutoCompletionDisposable } from './completions';
 import { runFilesTagsWtOptions } from './runFilesTagsWtOptions';
@@ -49,6 +49,7 @@ export async function activate(context: vscode.ExtensionContext) {
     globalThis.incrementalCheckBox = false;
     globalThis.schemaAutoCompletions = [];
     globalThis.activeEditorFileName = undefined;
+    globalThis.activeDocumentObj = undefined;
 
     for (let i = 0; i < executablesToCheck.length; i++) {
         let executable = executablesToCheck[i];
@@ -173,6 +174,7 @@ export async function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(
         vscode.commands.registerCommand('vscode-dataform-tools.showCompiledQueryWtDryRun', async (_editor) => {
             activeEditorFileName = _editor.fsPath;
+            activeDocumentObj = getVSCodeDocument();
             CompiledQueryPanel.getInstance(context.extensionUri, context, true, true, undefined);
         }));
 

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -64,5 +64,9 @@ declare global {
   var activeEditorFileName: string | undefined;
 }
 
+declare global {
+  var activeDocumentObj: any;
+}
+
 
 export {};

--- a/src/runFiles.ts
+++ b/src/runFiles.ts
@@ -3,8 +3,7 @@ import { getDataformActionCmdFromActionList, getDataformCompilationTimeoutFromCo
 
 export async function runCurrentFile(includDependencies: boolean, includeDownstreamDependents: boolean, fullRefresh: boolean) {
 
-
-    let document = getVSCodeDocument();
+    let document = getVSCodeDocument() || activeDocumentObj;
     if (!document) {
         return;
     }

--- a/src/runFiles.ts
+++ b/src/runFiles.ts
@@ -3,7 +3,7 @@ import { getDataformActionCmdFromActionList, getDataformCompilationTimeoutFromCo
 
 export async function runCurrentFile(includDependencies: boolean, includeDownstreamDependents: boolean, fullRefresh: boolean) {
 
-    let document = getVSCodeDocument() || activeDocumentObj;
+    let document = activeDocumentObj || getVSCodeDocument();
     if (!document) {
         return;
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -139,7 +139,7 @@ async function getDependentsOfTarget(targetToSearch: Target, dataformCompiledJso
 }
 
 export async function getCurrentFileMetadata(freshCompilation: boolean) {
-    let document = vscode.window.activeTextEditor?.document;
+    let document = activeDocumentObj || vscode.window.activeTextEditor?.document;
     if (!document) {
         return;
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -504,36 +504,25 @@ export async function getAllFilesWtAnExtension(workspaceFolder: string, extensio
 
 export function getDataformActionCmdFromActionList(actionsList: string[], workspaceFolder: string, dataformCompilationTimeoutVal: string, includDependencies: boolean, includeDownstreamDependents: boolean, fullRefresh: boolean) {
     let dataformCompilerOptions = getDataformCompilerOptions();
-    let dataformActionCmd = "";
+    let cmd = `dataform run ${workspaceFolder} ${dataformCompilerOptions} --timeout=${dataformCompilationTimeoutVal}`;
     for (let i = 0; i < actionsList.length; i++) {
         let fullTableName = actionsList[i];
         if (i === 0) {
             if (includDependencies) {
-                if (fullRefresh) {
-                    dataformActionCmd = (`dataform run ${workspaceFolder} ${dataformCompilerOptions} --timeout ${dataformCompilationTimeoutVal} --actions "${fullTableName}" --include-deps --full-refresh`);
-                } else {
-                    dataformActionCmd = (`dataform run ${workspaceFolder} ${dataformCompilerOptions} --timeout ${dataformCompilationTimeoutVal} --actions "${fullTableName}" --include-deps`);
-                }
-            } else if (includeDownstreamDependents) {
-                if (fullRefresh) {
-                    dataformActionCmd = (`dataform run ${workspaceFolder} ${dataformCompilerOptions} --timeout ${dataformCompilationTimeoutVal} --actions "${fullTableName}" --include-dependents --full-refresh`);
-                } else {
-                    dataformActionCmd = (`dataform run ${workspaceFolder} ${dataformCompilerOptions} --timeout ${dataformCompilationTimeoutVal} --actions "${fullTableName}" --include-dependents`);
-                }
+                cmd += ` --include-deps`;
             }
-            else {
-                if (fullRefresh) {
-                    dataformActionCmd = (`dataform run ${workspaceFolder} ${dataformCompilerOptions} --timeout ${dataformCompilationTimeoutVal} --actions "${fullTableName}" --full-refresh`);
-                } else {
-                    dataformActionCmd = `dataform run ${workspaceFolder} ${dataformCompilerOptions} --timeout ${dataformCompilationTimeoutVal} --actions "${fullTableName}"`;
-                }
+            if (includeDownstreamDependents) {
+                cmd += ` --include-dependents`;
             }
+            if (fullRefresh) {
+                cmd += ` --full-refresh`;
+            }
+            cmd += ` --actions "${fullTableName}"`;
         } else {
-            // TODO: Not sure what is this doing ?
-            dataformActionCmd += ` --actions "${fullTableName}"`;
+            cmd += ` --actions "${fullTableName}"`;
         }
     }
-    return dataformActionCmd;
+    return cmd;
 }
 
 export async function getDataformTags(compiledJson: DataformCompiledJson) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -350,7 +350,6 @@ export async function getTreeRootFromRef(): Promise<string | undefined> {
 export function getVSCodeDocument(): vscode.TextDocument | undefined {
     let document = vscode.window.activeTextEditor?.document;
     if (!document) {
-        vscode.window.showErrorMessage("VS Code document object was undefined");
         return;
     }
     return document;

--- a/src/views/register-preview-compiled-panel.ts
+++ b/src/views/register-preview-compiled-panel.ts
@@ -204,7 +204,8 @@ export class CompiledQueryPanel {
               case 'runModel':
                 const includeDependencies = message.value.includeDependencies;
                 const includeDependents  = message.value.includeDependents;
-                await runCurrentFile(includeDependencies, includeDependents, false);
+                const fullRefresh  = message.value.fullRefresh;
+                await runCurrentFile(includeDependencies, includeDependents, fullRefresh);
                 return;
               case 'lineageMetadata':
                 const fileMetadata  = this.centerPanel?._cachedResults?.fileMetadata;
@@ -481,12 +482,17 @@ export class CompiledQueryPanel {
                     <label class="model-checkbox-container">
                         <input type="checkbox" id="includeDependencies" class="checkbox"> 
                         <span class="custom-checkbox"></span>
-                        Include Dependencies
+                        Include Dependencies (upstream)
                     </label>
                     <label class="model-checkbox-container">
                         <input type="checkbox" id="includeDependents" class="checkbox"> 
                         <span class="custom-checkbox"></span>
-                        Include Dependents
+                        Include Dependents (downstream)
+                    </label>
+                    <label class="model-checkbox-container">
+                        <input type="checkbox" id="fullRefresh" class="checkbox"> 
+                        <span class="custom-checkbox"></span>
+                        full Refresh (Forces incremental tables to be rebuilt from scratch)
                     </label>
                 </div>
 

--- a/src/views/register-preview-compiled-panel.ts
+++ b/src/views/register-preview-compiled-panel.ts
@@ -439,7 +439,7 @@ export class CompiledQueryPanel {
                         <path d="M8.59 16.59L13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.41z"/>
                     </svg>
                 </div>
-                <span class="dependency-title" style="font-weight: bold;">Dependencies & Dependents</span>
+                <span class="dependency-title" style="font-weight: bold;">Data Lineage</span>
             </div>
             <div id="depsDiv" class="dependency-list">
             </div>

--- a/src/views/register-preview-compiled-panel.ts
+++ b/src/views/register-preview-compiled-panel.ts
@@ -196,6 +196,11 @@ export class CompiledQueryPanel {
             }
 
             switch (message.command) {
+              case 'previewResults':
+                if(message.value){
+                    await vscode.commands.executeCommand('vscode-dataform-tools.runQuery');
+                }
+                return;
               case 'runModel':
                 const includeDependencies = message.value.includeDependencies;
                 const includeDependents  = message.value.includeDependents;
@@ -484,9 +489,12 @@ export class CompiledQueryPanel {
                         Include Dependents
                     </label>
                 </div>
+
                 <div class="button-container">
-                    <button class="run-model" id="runModel">Run</button>
+                    <button class="run-model" id="previewResults" title="Preview the data in BigQuery like console before running the model">Data Preview</button>
+                    <button class="run-model" id="runModel" title="Execute the model in BigQuery with specified settings">Run</button>
                 </div>
+
             </div>
 
             <div id="codeBlock">

--- a/src/views/register-preview-compiled-panel.ts
+++ b/src/views/register-preview-compiled-panel.ts
@@ -188,8 +188,8 @@ export class CompiledQueryPanel {
             const now = Date.now();
             if(this.centerPanel){
                 if (now - this?.centerPanel?.lastMessageTime < this?.centerPanel?.DEBOUNCE_INTERVAL) {
-                    // TODO: vscode.postMessage form webview sends in multiple messages when active editor is switched
-                    // TODO: This is debounce hack build to avoid processing multiple messages and process only the first message
+                    // NOTE: vscode.postMessage form webview sends in multiple messages when active editor is switched
+                    // NOTE: This is debounce hack build to avoid processing multiple messages and process only the first message
                     return; 
                 }
                 this.centerPanel.lastMessageTime = now;


### PR DESCRIPTION
The change is largely made to make the extension features more visible to a more casual user. 

- [x] Able to run current file w/t dependencies & dependents 
- [x] Able to preview results 
- [x] test `getDataformActionCmdFromActionList`

Minor fixes for issues discovered while implementing this feature

- [x] If users active editor was compiled query web view and if they would have invoked a command to run current file previously it would not have been able to determine  the active document 
- [x] Avoid multiple invocations of api requests from web view if the user had switched active editor by implementing debounce 