### PR TITLE
feat: show column description in the  table schema 

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,6 @@ Open vscode command pallet by pressing <kbd>CTLR</kbd> + <kbd>SHIFT</kbd> + <kbd
 
 ## TODO
 
-- [ ] Show column description in schema of compiled query web view
 - [ ] Add BigQuery job link when assertion is executed
 - [ ] Handle case where user is not connected to internet or on vpn where network request for dry run cannot be made
 

--- a/media/js/showCompiledQuery.js
+++ b/media/js/showCompiledQuery.js
@@ -297,7 +297,7 @@ window.addEventListener('message', event => {
     if(compiledQuerySchemaNotAvailable && event?.data?.dryRunStat){
         noSchemaBlockDiv.innerHTML = "";
         const noSchemaHeader = document.createElement("header");
-        noSchemaHeader.innerHTML = "<h4>No schema available for operation defined in the current model</h4>";
+        noSchemaHeader.innerHTML = "<h4>Schema could not be infered for the transaction defined in the current model</h4>";
         noSchemaHeader.style.color = "#FFA500"; // orange
         noSchemaBlockDiv.appendChild(noSchemaHeader);
     }

--- a/media/js/showCompiledQuery.js
+++ b/media/js/showCompiledQuery.js
@@ -268,7 +268,7 @@ window.addEventListener('message', event => {
 
     let compiledQuerySchema =  event?.data?.compiledQuerySchema;
     if (compiledQuerySchema){
-        compiledQuerySchema = compiledQuerySchema.fields.map(({ name, type }) => ({ name, type }));
+        compiledQuerySchema = compiledQuerySchema.fields.map(({ name, type, description }) => ({ name, type, description }));
         new Tabulator("#schemaTable", {
             data: compiledQuerySchema,
             autoColumns: true,
@@ -284,7 +284,7 @@ window.addEventListener('message', event => {
             autoColumnsDefinitions: function(definitions) {
                 definitions.forEach(function(column) {
                     column.headerFilter = "input";
-                    column.headerFilterLiveFilter = true; // Change this line
+                    column.headerFilterLiveFilter = true;
                 });
                 return definitions;
             },

--- a/media/js/showCompiledQuery.js
+++ b/media/js/showCompiledQuery.js
@@ -293,10 +293,11 @@ window.addEventListener('message', event => {
         });
     }
 
-    if(!compiledQuerySchema && event?.data?.dryRunStat){
+    const compiledQuerySchemaNotAvailable = compiledQuerySchema && compiledQuerySchema.length === 1 && compiledQuerySchema[0].name === "" && compiledQuerySchema[0].type === "";
+    if(compiledQuerySchemaNotAvailable && event?.data?.dryRunStat){
         noSchemaBlockDiv.innerHTML = "";
         const noSchemaHeader = document.createElement("header");
-        noSchemaHeader.innerHTML = "<h4>No schema available for operation defined in the current model. Showing pervious models schema if available</h4>";
+        noSchemaHeader.innerHTML = "<h4>No schema available for operation defined in the current model</h4>";
         noSchemaHeader.style.color = "#FFA500"; // orange
         noSchemaBlockDiv.appendChild(noSchemaHeader);
     }

--- a/media/js/showCompiledQuery.js
+++ b/media/js/showCompiledQuery.js
@@ -10,6 +10,7 @@ const runModelButton = document.getElementById('runModel');
 const includeDependenciesCheckbox = document.getElementById('includeDependencies');
 const includeDependentsCheckBox = document.getElementById('includeDependents');
 const fullRefreshCheckBox = document.getElementById('fullRefresh');
+const noSchemaBlockDiv = document.getElementById("noSchemaBlock");
 
 function runModelClickHandler() {
     runModelButton.disabled = true;
@@ -268,6 +269,7 @@ window.addEventListener('message', event => {
 
     let compiledQuerySchema =  event?.data?.compiledQuerySchema;
     if (compiledQuerySchema){
+        noSchemaBlockDiv.innerHTML = "";
         compiledQuerySchema = compiledQuerySchema.fields.map(({ name, type, description }) => ({ name, type, description }));
         new Tabulator("#schemaTable", {
             data: compiledQuerySchema,
@@ -289,6 +291,14 @@ window.addEventListener('message', event => {
                 return definitions;
             },
         });
+    }
+
+    if(!compiledQuerySchema && event?.data?.dryRunStat){
+        noSchemaBlockDiv.innerHTML = "";
+        const noSchemaHeader = document.createElement("header");
+        noSchemaHeader.innerHTML = "<h4>No schema available for operation defined in the current model. Showing pervious models schema if available</h4>";
+        noSchemaHeader.style.color = "#FFA500"; // orange
+        noSchemaBlockDiv.appendChild(noSchemaHeader);
     }
 
     compiledQueryloadingIcon.style.display = "none";

--- a/src/bigqueryDryRun.ts
+++ b/src/bigqueryDryRun.ts
@@ -1,4 +1,5 @@
 import { getBigQueryClient, checkAuthentication, handleBigQueryError } from './bigqueryClient';
+import { BigQueryDryRunResponse } from './types';
 
 export function getLineAndColumnNumberFromErrorMessage(errorMessage: string) {
     //e.g. error 'Unrecognized name: SSY_LOC_ID; Did you mean ASSY_LOC_ID? at [65:7]'
@@ -15,7 +16,7 @@ export function getLineAndColumnNumberFromErrorMessage(errorMessage: string) {
     };
 }
 
-export async function queryDryRun(query: string) {
+export async function queryDryRun(query: string) : Promise<BigQueryDryRunResponse> {
     await checkAuthentication();
 
     const bigqueryClient = getBigQueryClient();

--- a/src/bigqueryDryRun.ts
+++ b/src/bigqueryDryRun.ts
@@ -17,6 +17,15 @@ export function getLineAndColumnNumberFromErrorMessage(errorMessage: string) {
 }
 
 export async function queryDryRun(query: string) : Promise<BigQueryDryRunResponse> {
+    if (query === "" || !query) {
+        return {
+            schema: undefined,
+            location: undefined,
+            statistics: { totalBytesProcessed: "0 GB" },
+            error: { hasError: false, message: "" }
+        };
+    }
+
     await checkAuthentication();
 
     const bigqueryClient = getBigQueryClient();
@@ -26,15 +35,6 @@ export async function queryDryRun(query: string) : Promise<BigQueryDryRunRespons
             location: undefined,
             statistics: { totalBytesProcessed: "" },
             error: { hasError: true, message: "BigQuery client not available." }
-        };
-    }
-
-    if (query === "" || !query) {
-        return {
-            schema: undefined,
-            location: undefined,
-            statistics: { totalBytesProcessed: "0 GB" },
-            error: { hasError: false, message: "" }
         };
     }
 

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -1,4 +1,4 @@
-import { DataformCompiledJson } from "./types";
+import { CompiledQuerySchema, DataformCompiledJson } from "./types";
 import * as vscode from 'vscode';
 
 declare global {
@@ -49,7 +49,7 @@ declare global {
 
 
 declare global {
-  var compiledQuerySchema: any | undefined;
+  var compiledQuerySchema: CompiledQuerySchema | undefined;
 }
 
 declare global {

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,7 +15,7 @@ export interface Table {
     actionDescriptor:ActionDescription;
 }
 
-interface ActionDescription{
+export interface ActionDescription{
     description: string;
     columns: Column[]
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,3 @@
-import { UnaryExpression } from "typescript";
 
 export interface Table {
     type: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,17 @@ export interface Table {
     incrementalPreOps: string[];
     dependencyTargets: Target[];
     bigquery: TableBigQueryConfig;
+    actionDescriptor:ActionDescription;
+}
+
+interface ActionDescription{
+    description: string;
+    columns: Column[]
+}
+
+interface Column {
+    path: string[];
+    descrition: string;
 }
 
 export interface QueryMeta {
@@ -105,14 +116,6 @@ export interface DryRunError {
     };
 }
 
-export interface BigQueryDryRunResponse {
-    schema : any;
-    statistics: {
-        totalBytesProcessed: string;
-    };
-    error: DryRunError;
-}
-
 export interface ConfigBlockMetadata {
     startLine: number;
     endLine: number;
@@ -161,3 +164,41 @@ export type GraphError = {
   error: string;
   fileName: string;
 };
+
+export interface ColumnMetadata {
+    name: string;
+    type: string;
+    mode: string;
+};
+
+export interface CompiledQuerySchema {
+    fields: ColumnMetadata[]
+};
+
+export interface ErrorLocation {
+        line: number;
+        column: number;
+};
+
+export interface BigQueryDryRunResponse {
+    schema: any; //TODO: add type here
+    location: string | undefined;
+    statistics: {
+        totalBytesProcessed: string; // e.g. "0 GB", "1.234 GB"
+    };
+    error: {
+        hasError: boolean;
+        message: string;
+        location?: ErrorLocation;
+    };
+}
+
+export interface ColumnMetadata {
+    name: string;
+    type: string;
+    mode: string;
+}
+
+export interface CompiledQuerySchema {
+    fields:  ColumnMetadata[];
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -169,7 +169,7 @@ export interface ColumnMetadata {
     name: string;
     type: string;
     mode: string;
-    description:string;
+    description?:string;
 };
 
 export interface CompiledQuerySchema {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import { UnaryExpression } from "typescript";
 
 export interface Table {
     type: string;
@@ -182,7 +183,7 @@ export interface ErrorLocation {
 };
 
 export interface BigQueryDryRunResponse {
-    schema: any; //TODO: add type here
+    schema: CompiledQuerySchema | undefined;
     location: string | undefined;
     statistics: {
         totalBytesProcessed: string; // e.g. "0 GB", "1.234 GB"

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,9 +20,9 @@ interface ActionDescription{
     columns: Column[]
 }
 
-interface Column {
+export interface Column {
     path: string[];
-    descrition: string;
+    description: string;
 }
 
 export interface QueryMeta {

--- a/src/types.ts
+++ b/src/types.ts
@@ -169,6 +169,7 @@ export interface ColumnMetadata {
     name: string;
     type: string;
     mode: string;
+    description:string;
 };
 
 export interface CompiledQuerySchema {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1015,14 +1015,15 @@ export async function dryRunAndShowDiagnostics(curFileMeta:any, queryAutoCompMet
     }
 
     // take ~400 to 1300ms depending on api response times, faster if `cacheHit`
-    let [dryRunResult, preOpsDryRunResult, postOpsDryRunResult] = await Promise.all([
+    let [dryRunResult, dryRunResultMainQuery, preOpsDryRunResult, postOpsDryRunResult] = await Promise.all([
         queryDryRun(queryToDryRun),
+        queryDryRun(currFileMetadata.queryMeta.tableOrViewQuery),
         //TODO: If pre_operations block has an error the diagnostics wont be placed at correct place in main query block
         queryDryRun(currFileMetadata.queryMeta.preOpsQuery),
         queryDryRun(currFileMetadata.queryMeta.postOpsQuery)
     ]);
 
-    compiledQuerySchema = dryRunResult.schema;
+    compiledQuerySchema = dryRunResult.schema || dryRunResultMainQuery.schema;
 
     if (dryRunResult.error.hasError || preOpsDryRunResult.error.hasError || postOpsDryRunResult.error.hasError) {
         if (!sqlxBlockMetadata && curFileMeta.pathMeta.extension === ".sqlx") {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import fs from 'fs';
 import path from 'path';
 import { execSync, spawn } from 'child_process';
-import { DataformCompiledJson, TablesWtFullQuery, SqlxBlockMetadata, GraphError, Target, Table, Assertion, Operation } from './types';
+import { DataformCompiledJson, TablesWtFullQuery, SqlxBlockMetadata, GraphError, Target, Table, Assertion, Operation, CompiledQuerySchema } from './types';
 import { queryDryRun } from './bigqueryDryRun';
 import { setDiagnostics } from './setDiagnostics';
 import { assertionQueryOffset, tableQueryOffset, incrementalTableOffset } from './constants';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -611,7 +611,8 @@ export async function getQueryMetaForCurrentFile(relativeFilePath: string, compi
                 postOps: table.postOps,
                 dependencyTargets: table.dependencyTargets,
                 incrementalQuery: table?.incrementalQuery ?? "",
-                incrementalPreOps: table?.incrementalPreOps ?? []
+                incrementalPreOps: table?.incrementalPreOps ?? [],
+                actionDescriptor: table?.actionDescriptor
             };
             finalTables.push(tableFound);
             break;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import fs from 'fs';
 import path from 'path';
 import { execSync, spawn } from 'child_process';
-import { DataformCompiledJson, TablesWtFullQuery, SqlxBlockMetadata, GraphError, Target, Table, Assertion, Operation, CompiledQuerySchema } from './types';
+import { DataformCompiledJson, TablesWtFullQuery, SqlxBlockMetadata, GraphError, Target, Table, Assertion, Operation } from './types';
 import { queryDryRun } from './bigqueryDryRun';
 import { setDiagnostics } from './setDiagnostics';
 import { assertionQueryOffset, tableQueryOffset, incrementalTableOffset } from './constants';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1027,15 +1027,14 @@ export async function dryRunAndShowDiagnostics(curFileMeta:any, queryAutoCompMet
     }
 
     // take ~400 to 1300ms depending on api response times, faster if `cacheHit`
-    let [dryRunResult, dryRunResultMainQuery, preOpsDryRunResult, postOpsDryRunResult] = await Promise.all([
+    let [dryRunResult, preOpsDryRunResult, postOpsDryRunResult] = await Promise.all([
         queryDryRun(queryToDryRun),
-        queryDryRun(currFileMetadata.queryMeta.tableOrViewQuery),
         //TODO: If pre_operations block has an error the diagnostics wont be placed at correct place in main query block
         queryDryRun(currFileMetadata.queryMeta.preOpsQuery),
         queryDryRun(currFileMetadata.queryMeta.postOpsQuery)
     ]);
 
-    compiledQuerySchema = dryRunResult.schema || dryRunResultMainQuery.schema;
+    compiledQuerySchema = dryRunResult.schema;
 
     if (dryRunResult.error.hasError || preOpsDryRunResult.error.hasError || postOpsDryRunResult.error.hasError) {
         if (!sqlxBlockMetadata && curFileMeta.pathMeta.extension === ".sqlx") {

--- a/src/views/register-preview-compiled-panel.ts
+++ b/src/views/register-preview-compiled-panel.ts
@@ -345,7 +345,7 @@ export class CompiledQueryPanel {
 
         if (compiledQuerySchema?.fields) {
             const curFileActionDescriptor:ActionDescription = curFileMeta.fileMetadata.tables[0].actionDescriptor;
-            if (curFileActionDescriptor) {
+            if (curFileActionDescriptor?.columns) {
 
                 const columnMap = new Map(
                 curFileActionDescriptor.columns.map((column: Column) => [column.path[0], column.description || ""])

--- a/src/views/register-preview-compiled-panel.ts
+++ b/src/views/register-preview-compiled-panel.ts
@@ -358,6 +358,8 @@ export class CompiledQueryPanel {
                     }
                 });
             }
+        } else {
+            compiledQuerySchema = {fields: [{"name": "", type:"", mode: ""}]};
         }
 
         if(showCompiledQueryInVerticalSplitOnSave || forceShowInVeritcalSplit){

--- a/src/views/register-preview-compiled-panel.ts
+++ b/src/views/register-preview-compiled-panel.ts
@@ -4,6 +4,7 @@ import { compiledQueryWtDryRun, dryRunAndShowDiagnostics, gatherQueryAutoComplet
 import path from "path";
 import { getLiniageMetadata } from "../getLineageMetadata";
 import { runCurrentFile } from "../runFiles";
+import { Table } from "../types";
 
 function showLoadingProgress(
     title: string,
@@ -110,7 +111,7 @@ export class CompiledQueryPanel {
     public currentFileMetadata: any;
     private lastMessageTime = 0;
     private readonly DEBOUNCE_INTERVAL = 300; // milliseconds
-    private _cachedResults?: {fileMetadata: any, curFileMeta:any, targetTableOrView:any, errorMessage: string, dryRunStat:any, location: string};
+    private _cachedResults?: {fileMetadata: any, curFileMeta:any, targetTableOrView:any, errorMessage: string, dryRunStat:any, location: string|undefined};
     private static readonly viewType = "CenterPanel";
     private constructor(public readonly webviewPanel: WebviewPanel, private readonly _extensionUri: Uri, public extensionContext: ExtensionContext, forceShowVerticalSplit:boolean, currentFileMetadata:any) {
         this.updateView(forceShowVerticalSplit, currentFileMetadata);
@@ -325,7 +326,7 @@ export class CompiledQueryPanel {
         let dryRunResult = await dryRunAndShowDiagnostics(curFileMeta, queryAutoCompMeta, curFileMeta.document, diagnosticCollection, false);
         let dryRunStat = dryRunResult?.statistics?.totalBytesProcessed;
         let errorMessage = dryRunResult?.error.message;
-        const location:string = dryRunResult?.location?.toLowerCase();
+        const location = dryRunResult?.location?.toLowerCase();
         if(!errorMessage){
             errorMessage = " ";
         }else if (errorMessage ==="BigQuery client not available."){
@@ -340,6 +341,20 @@ export class CompiledQueryPanel {
         }
         if(!dryRunStat){
             dryRunStat = "0 GB";
+        }
+
+        if(CACHED_COMPILED_DATAFORM_JSON){
+            CACHED_COMPILED_DATAFORM_JSON.tables.forEach((table:Table) => {
+                if(table.fileName === curFileMeta.pathMeta.relativeFilePath ){
+                    const columnsDescriptions = table?.actionDescriptor?.columns;
+                    if(columnsDescriptions){
+                        columnsDescriptions.forEach((c:any) => {
+                            console.log(c?.path[0]);
+                            console.log(c?.description);
+                        });
+                    }
+                }
+            });
         }
 
         if(showCompiledQueryInVerticalSplitOnSave || forceShowInVeritcalSplit){

--- a/src/views/register-preview-compiled-panel.ts
+++ b/src/views/register-preview-compiled-panel.ts
@@ -473,6 +473,7 @@ export class CompiledQueryPanel {
 
 
         <div id="schemaBlock" style="display: none; margin-top: 20px;">
+            <div id="noSchemaBlock"> </div>
             <table id="schemaTable" class="display" width="100%"></table>
         </div>
 

--- a/src/views/register-preview-compiled-panel.ts
+++ b/src/views/register-preview-compiled-panel.ts
@@ -4,7 +4,7 @@ import { compiledQueryWtDryRun, dryRunAndShowDiagnostics, gatherQueryAutoComplet
 import path from "path";
 import { getLiniageMetadata } from "../getLineageMetadata";
 import { runCurrentFile } from "../runFiles";
-import { ColumnMetadata, Table, Column } from "../types";
+import { ColumnMetadata, Table, Column, ActionDescription } from "../types";
 
 function showLoadingProgress(
     title: string,
@@ -343,27 +343,22 @@ export class CompiledQueryPanel {
             dryRunStat = "0 GB";
         }
 
-        console.time("compiledQuerySchemaColumns");
+        if (compiledQuerySchema?.fields) {
+            const curFileActionDescriptor:ActionDescription = curFileMeta.fileMetadata.tables[0].actionDescriptor;
+            if (curFileActionDescriptor) {
 
-        if (compiledQuerySchema?.fields && CACHED_COMPILED_DATAFORM_JSON?.tables) {
-            const targetTable = CACHED_COMPILED_DATAFORM_JSON.tables.find(
-                (table: Table) => table.fileName === curFileMeta.pathMeta.relativeFilePath
-            );
-
-            if (targetTable?.actionDescriptor?.columns) {
                 const columnMap = new Map(
-                targetTable.actionDescriptor.columns.map((column: Column) => [column.path[0], column.description || ""])
+                curFileActionDescriptor.columns.map((column: Column) => [column.path[0], column.description || ""])
                 );
 
                 compiledQuerySchema.fields.forEach((columnMetadata: ColumnMetadata) => {
-                const description = columnMap.get(columnMetadata.name);
-                if (description !== undefined) {
-                    columnMetadata.description = description;
-                }
+                    const description = columnMap.get(columnMetadata.name);
+                    if (description !== undefined) {
+                        columnMetadata.description = description;
+                    }
                 });
             }
         }
-        console.timeEnd("compiledQuerySchemaColumns");
 
         if(showCompiledQueryInVerticalSplitOnSave || forceShowInVeritcalSplit){
             await webview.postMessage({


### PR DESCRIPTION
Add description column to the table schema shown in the compiled query web view view nav bar. From my testing on Dataform graph with approx 280 nodes this functionality adds **less than 20ms overhead**. Also since computation is performed post the compiled query is displayed, the perceived latency is quite low / imperceptible to human eye.

**Other minor changes** 

- [x] No need to check BigQuery client if query is undefined or ""
- [x] If schema is not available for preOps + main query use schema from main query if available. This does not seem have any additional performance penalty due to the function calls being wrapped in `Promise.all`
- [x] make changes based on resolution from https://github.com/ashish10alex/vscode-dataform-tools/pull/80