### PR TITLE
fix: dry run not working with @@query_label

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1013,6 +1013,9 @@ export async function dryRunAndShowDiagnostics(curFileMeta:any, queryAutoCompMet
         queryToDryRun = incrementalQuery;
     }
 
+    //drop @@query_labels if exists -- else queryMeta breaks
+    queryToDryRun = queryToDryRun.replace(/SET\s+@@query_label\s*=\s*".*"\s*;/g, '');
+
     // take ~400 to 1300ms depending on api response times, faster if `cacheHit`
     let [dryRunResult, preOpsDryRunResult, postOpsDryRunResult] = await Promise.all([
         queryDryRun(queryToDryRun),


### PR DESCRIPTION
While investigating the issue with dry runs failing when `@@query_labels` is set, I couldn’t pinpoint the exact cause. However, I’ve implemented a quick (and perhaps somewhat dirty) solution: dropping the `@@query_labels` statement during dry runs. 

#### Implementation:
The solution uses a regular expression to identify and remove the `@@query_labels` statement. While the regex might not be entirely foolproof, it has worked in all the scenarios I’ve tested.

#### Rationale:
Since query labels should not affect dry runs, I don’t foresee any issues with this approach. That said, if you have concerns or an alternative solution, Feel free to change it or let me know :-)