### PR TITLE
feat: propagate pre and post operation errors to webview

### DIFF
--- a/src/setDiagnostics.ts
+++ b/src/setDiagnostics.ts
@@ -26,6 +26,7 @@ export function setDiagnostics(document: vscode.TextDocument, dryRunError: DryRu
             errLineNumber = (sqlQueryStartLineNumber + (errLineNumber - offSet)) - preOpsOffset;
 
             const range = new vscode.Range(new vscode.Position(errLineNumber, errColumnNumber), new vscode.Position(errLineNumber, errColumnNumber + 5));
+            dryRunError.message = "(fullQuery): " + dryRunError.message;
             const regularBlockDiagnostic = new vscode.Diagnostic(range, dryRunError.message, severity);
             diagnostics.push(regularBlockDiagnostic);
         }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1039,7 +1039,7 @@ export async function dryRunAndShowDiagnostics(curFileMeta:any, queryAutoCompMet
     if (dryRunResult.error.hasError || preOpsDryRunResult.error.hasError || postOpsDryRunResult.error.hasError) {
         if (!sqlxBlockMetadata && curFileMeta.pathMeta.extension === ".sqlx") {
             vscode.window.showErrorMessage("Could not parse sqlx file");
-            [undefined , undefined];
+            [undefined , undefined, undefined];
         }
 
         let offSet = 0;
@@ -1054,7 +1054,7 @@ export async function dryRunAndShowDiagnostics(curFileMeta:any, queryAutoCompMet
         if (sqlxBlockMetadata) {
             setDiagnostics(document, dryRunResult.error, preOpsDryRunResult.error, postOpsDryRunResult.error, diagnosticCollection, sqlxBlockMetadata, offSet);
         }
-        return [dryRunResult, preOpsDryRunResult];
+        return [dryRunResult, preOpsDryRunResult, postOpsDryRunResult];
     }
 
     if (!showCompiledQueryInVerticalSplitOnSave) {
@@ -1065,7 +1065,7 @@ export async function dryRunAndShowDiagnostics(curFileMeta:any, queryAutoCompMet
         });
         vscode.window.showInformationMessage(`GB: ${dryRunResult.statistics.totalBytesProcessed} - ${combinedTableIds}`);
     }
-    return [dryRunResult, preOpsDryRunResult];
+    return [dryRunResult, preOpsDryRunResult, postOpsDryRunResult];
 }
 
 export async function compiledQueryWtDryRun(document: vscode.TextDocument, diagnosticCollection: vscode.DiagnosticCollection, showCompiledQueryInVerticalSplitOnSave: boolean) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1008,9 +1008,9 @@ export async function dryRunAndShowDiagnostics(curFileMeta:any, queryAutoCompMet
     if (currFileMetadata.queryMeta.type === "table" || currFileMetadata.queryMeta.type === "view") {
         let preOpsQuery = currFileMetadata.queryMeta.preOpsQuery;
         if(preOpsQuery && preOpsQuery !== ""){
-            currFileMetadata.queryMeta.preOpsQuery = replaceQueryLabelWtEmptyStringForDryRun(preOpsQuery);
+            preOpsQuery = replaceQueryLabelWtEmptyStringForDryRun(preOpsQuery);
         }
-        queryToDryRun = currFileMetadata.queryMeta.preOpsQuery + currFileMetadata.queryMeta.tableOrViewQuery;
+        queryToDryRun = preOpsQuery + currFileMetadata.queryMeta.tableOrViewQuery;
     } else if (currFileMetadata.queryMeta.type === "assertion") {
         queryToDryRun = currFileMetadata.queryMeta.assertionQuery;
     } else if (currFileMetadata.queryMeta.type === "operation") {
@@ -1039,7 +1039,7 @@ export async function dryRunAndShowDiagnostics(curFileMeta:any, queryAutoCompMet
     if (dryRunResult.error.hasError || preOpsDryRunResult.error.hasError || postOpsDryRunResult.error.hasError) {
         if (!sqlxBlockMetadata && curFileMeta.pathMeta.extension === ".sqlx") {
             vscode.window.showErrorMessage("Could not parse sqlx file");
-            return;
+            [undefined , undefined];
         }
 
         let offSet = 0;
@@ -1054,7 +1054,7 @@ export async function dryRunAndShowDiagnostics(curFileMeta:any, queryAutoCompMet
         if (sqlxBlockMetadata) {
             setDiagnostics(document, dryRunResult.error, preOpsDryRunResult.error, postOpsDryRunResult.error, diagnosticCollection, sqlxBlockMetadata, offSet);
         }
-        return dryRunResult;
+        return [dryRunResult, preOpsDryRunResult];
     }
 
     if (!showCompiledQueryInVerticalSplitOnSave) {
@@ -1065,7 +1065,7 @@ export async function dryRunAndShowDiagnostics(curFileMeta:any, queryAutoCompMet
         });
         vscode.window.showInformationMessage(`GB: ${dryRunResult.statistics.totalBytesProcessed} - ${combinedTableIds}`);
     }
-    return dryRunResult;
+    return [dryRunResult, preOpsDryRunResult];
 }
 
 export async function compiledQueryWtDryRun(document: vscode.TextDocument, diagnosticCollection: vscode.DiagnosticCollection, showCompiledQueryInVerticalSplitOnSave: boolean) {

--- a/src/views/register-preview-compiled-panel.ts
+++ b/src/views/register-preview-compiled-panel.ts
@@ -323,9 +323,9 @@ export class CompiledQueryPanel {
             return;
         }
 
-        let dryRunResult = await dryRunAndShowDiagnostics(curFileMeta, queryAutoCompMeta, curFileMeta.document, diagnosticCollection, false);
+        const [dryRunResult, preOpsDryRunResult] = await dryRunAndShowDiagnostics(curFileMeta, queryAutoCompMeta, curFileMeta.document, diagnosticCollection, false);
         let dryRunStat = dryRunResult?.statistics?.totalBytesProcessed;
-        let errorMessage = dryRunResult?.error.message;
+        let errorMessage = (preOpsDryRunResult?.error.message ? preOpsDryRunResult?.error.message + "<br>" : "") + dryRunResult?.error.message;
         const location = dryRunResult?.location?.toLowerCase();
         if(!errorMessage){
             errorMessage = " ";

--- a/src/views/register-preview-compiled-panel.ts
+++ b/src/views/register-preview-compiled-panel.ts
@@ -323,9 +323,9 @@ export class CompiledQueryPanel {
             return;
         }
 
-        const [dryRunResult, preOpsDryRunResult] = await dryRunAndShowDiagnostics(curFileMeta, queryAutoCompMeta, curFileMeta.document, diagnosticCollection, false);
+        const [dryRunResult, preOpsDryRunResult, postOpsDryRunResult] = await dryRunAndShowDiagnostics(curFileMeta, queryAutoCompMeta, curFileMeta.document, diagnosticCollection, false);
         let dryRunStat = dryRunResult?.statistics?.totalBytesProcessed;
-        let errorMessage = (preOpsDryRunResult?.error.message ? preOpsDryRunResult?.error.message + "<br>" : "") + dryRunResult?.error.message;
+        let errorMessage = (preOpsDryRunResult?.error.message ? preOpsDryRunResult?.error.message + "<br>" : "") + dryRunResult?.error.message + (postOpsDryRunResult?.error.message ?  "<br>" + postOpsDryRunResult?.error.message: "");
         const location = dryRunResult?.location?.toLowerCase();
         if(!errorMessage){
             errorMessage = " ";


### PR DESCRIPTION
feat: propagate pre and post operation errors to webview. see example in screenshot below 

![CleanShot 2024-12-26 at 13 22 13@2x](https://github.com/user-attachments/assets/8413b9ff-669b-40b0-be88-e7a646414a9c)

-- 

query text to reproduce 

```sql
config {
  type: 'table',
  assertions: {
    uniqueKey: ["uniqueId"]
  }
}

pre_operations {
 SET @@query_label = "key:value";
 declare SOME_DATE DATE DEFAULT CURRENT_DATE;
}

post_operations {
  SELECT
     URRENT_TIMESTAMP() AS SOME_TIMESTAMP
}


SELECT
  1                AS UNIQUEID
  , "myData"       AS SOMECOLUMN
  , URRENT_DATE() AS TODAYS_DATE
```

