### PR TITLE
fix: #89 semicolon added to end of operations

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -675,7 +675,7 @@ export async function getQueryMetaForCurrentFile(relativeFilePath: string, compi
         if (operation) {
             queryMeta.type = "operation";
             const finalOperationQuery = operation.queries.reduce((acc, query, index) => {
-                return acc + `\n -- Operations: [${index + 1}] \n${query}\n ;`;
+                return acc + `\n -- Operations: [${index + 1}] \n${query}\n`;
             }, "");
 
             queryMeta.operationsQuery += finalOperationQuery;


### PR DESCRIPTION
Fixes: https://github.com/ashish10alex/vscode-dataform-tools/issues/89

Although the underlying data structure in operations key in `dataform compile --json`  in `queries` which is a list. So this would indicate that there could be multiple of these. However, I am yet to see an example of such a case. which is why we had added a semicolon as a terminator. For now we are moving to empty string as delimiter.  Such that the final output on webview is consistent with what is shown in GCP Dataform UI.  