### PR TITLE
feat: support for native `format Document` 

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,6 +153,13 @@
                 "command": "vscode-dataform-tools.dependencyGraphPanel",
                 "category": "Dataform",
                 "title": "Show dependency graph"
+            },
+            {
+                "command": "vscode-dataform-tools.formatDocument",
+                "category": "Dataform",
+                "title": "Format Document",
+                "icon": "$(sparkle)",
+                "group": "navigation@0"
             }
         ],
         "languages": [
@@ -192,7 +199,7 @@
                     "group": "navigation@3"
                 },
                 {
-                    "command": "vscode-dataform-tools.formatCurrentfile",
+                    "command": "vscode-dataform-tools.formatDocument",
                     "when": "resourceExtname == .sqlx || resourceExtname == .js",
                     "group": "navigation@0"
                 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
         "onCommand:extension.runTag",
         "onCommand:extension.runTagWtDeps",
         "onCommand:extension.runTagWtDownstreamDeps",
-        "onCommand:extension.formatCurrentfile",
         "onCommand:extension.runFilesTagsWtOptions",
         "onCommand:extension.showCompiledQueryInWebView",
         "onCommand:extension.showFileMetadataForSidePanel",
@@ -132,13 +131,6 @@
                 "title": "Run current file",
                 "icon": "$(play)",
                 "group": "navigation"
-            },
-            {
-                "command": "vscode-dataform-tools.formatCurrentfile",
-                "category": "Dataform",
-                "title": "Format current file",
-                "icon": "$(sparkle)",
-                "group": "navigation@0"
             },
             {
                 "command": "vscode-dataform-tools.runCurrentFileWtDeps",

--- a/package.json
+++ b/package.json
@@ -281,7 +281,7 @@
                 "vscode-dataform-tools.compileAndDryRunBeforeFormatting": {
                     "type": "boolean",
                     "default": true,
-                    "markdownDescription": "WARNING!!: only turn this on if you are confident that your query compiles without errors. Syntax error in config/pre/post operation blocks termination can result in unexpeted results while formatting"
+                    "markdownDescription": "Disable this to experience faster formatting, especially if you have enabled format on save. `::WARNING::` only turn this on if you are confident that your query compiles without errors. Syntax error in config/pre/post operation blocks termination can result in unexpeted results while formatting"
                 },
                 "vscode-dataform-tools.bigqueryAuthenticationCheck": {
                     "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -300,6 +300,11 @@
                     "markdownDescription": "Enable debug logging to help troubleshoot issues. Logs will appear in the 'Dataform Tools' output channel."
                 }
             }
+        },
+        "configurationDefaults": {
+            "[sqlx]": {
+                "editor.formatOnSave": false
+            }
         }
     },
     "scripts": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -261,6 +261,12 @@ export async function activate(context: vscode.ExtensionContext) {
         })
     );
 
+    context.subscriptions.push(
+        vscode.commands.registerCommand('vscode-dataform-tools.formatDocument', () => {
+            vscode.commands.executeCommand('editor.action.formatDocument');
+        })
+    );
+
     logger.info('Dataform Tools extension activated successfully');
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,7 +14,7 @@ import { sourcesAutoCompletionDisposable, dependenciesAutoCompletionDisposable, 
 import { runFilesTagsWtOptions } from './runFilesTagsWtOptions';
 import { AssertionRunnerCodeLensProvider, TagsRunnerCodeLensProvider } from './codeLensProvider';
 import { cancelBigQueryJob } from './bigqueryRunQuery';
-import { formatCurrentFile, formatCurrentFileWithDataform } from './formatCurrentFile';
+import { formatDataformSqlxFile } from './formatCurrentFile';
 import { previewQueryResults, runQueryInPanel } from './previewQueryResults';
 import { runTag } from './runTag';
 import { runCurrentFile } from './runFiles';
@@ -190,17 +190,18 @@ export async function activate(context: vscode.ExtensionContext) {
         vscode.commands.registerCommand('vscode-dataform-tools.runFilesTagsWtOptions', runFilesTagsWtOptions)
     );
 
-    /**
-     * NOTE: Takes ~2 seconds as we compile the project (~200 nodes ) and dry run the file to safely format the .sqlx file to avoid loosing user code due to incorrect parsing due to unexptected block terminations, etc.
-     */
-    context.subscriptions.push(vscode.commands.registerCommand('vscode-dataform-tools.formatCurrentfile', async () => {
-        let formattingCli = vscode.workspace.getConfiguration("vscode-dataform-tools").get("formattingCli");
-        if (formattingCli === "sqlfluff") {
-            await formatCurrentFile(diagnosticCollection);
-        } else if (formattingCli === "dataform") {
-            await formatCurrentFileWithDataform();
-        }
-    }));
+
+    context.subscriptions.push(
+        vscode.languages.registerDocumentFormattingEditProvider('sqlx', {
+            async provideDocumentFormattingEdits(document): Promise<vscode.TextEdit[]> {
+                const formattingOutput = await formatDataformSqlxFile(document);
+                if (formattingOutput && formattingOutput.length > 0) {
+                    return formattingOutput;
+                }
+                return []; // Return empty array if no formatting was done
+            }
+        })
+    );
 
     context.subscriptions.push(vscode.commands.registerCommand('vscode-dataform-tools.runCurrentFileWtDeps', () => { runCurrentFile(true, false, false); }));
 

--- a/src/views/register-preview-compiled-panel.ts
+++ b/src/views/register-preview-compiled-panel.ts
@@ -8,7 +8,8 @@ import { ColumnMetadata,  Column, ActionDescription, CurrentFileMetadata, Suppor
 import { currencySymbolMapping, getFileNotFoundErrorMessageForWebView } from "../constants";
 import { costEstimator } from "../costEstimator";
 import { getModelLastModifiedTime } from "../bigqueryDryRun";
-
+import { formatCurrentFile } from "../formatCurrentFile";
+import * as fs from 'fs';
 function showLoadingProgress(
     title: string,
     operation: (
@@ -254,7 +255,15 @@ export class CompiledQueryPanel {
                 }
                 return;
               case 'formatCurrentFile':
-                    await vscode.commands.executeCommand('vscode-dataform-tools.formatCurrentfile');
+                const formattedText:any = await formatCurrentFile(diagnosticCollection);
+                const activeEditorFilePath = activeDocumentObj?.uri.fsPath;
+                if(activeEditorFilePath){
+                    fs.writeFile(activeEditorFilePath, formattedText, (err: any) => {
+                        if (err) {throw err;};
+                        vscode.window.showInformationMessage(`Formatted: ${path.basename(activeEditorFilePath)}`);
+                        return;
+                    });
+                }
                 return;
               case 'lineageMetadata':
                 const fileMetadata  = this.centerPanel?._cachedResults?.fileMetadata;


### PR DESCRIPTION
Solves: https://github.com/ashish10alex/vscode-dataform-tools/issues/117

- [x] Able to do formatting using `format Document` . This enables user to use format on save. It will be wise to disable `compileAndDryRunBeforeFormatting`  to avoid latency. `compileAndDryRunBeforeFormatting` options checks if the compilation and dry run of the file passes successfully before formatting. 
- [x] Test on windows 
- [x] Ensure no regression or unexpected artefacts    