### PR TITLE
fix: unable to use bigquery client when global default project does have BigQuery enabled 

### DIFF
--- a/package.json
+++ b/package.json
@@ -302,7 +302,8 @@
                 "vscode-dataform-tools.bigqueryProjectId": {
                     "type": "string",
                     "default": null,
-                    "markdownDescription": "Project ID to use for BigQuery queries. If not provided, the project ID will be inferred from the environment."
+                    "markdownDescription": "Project ID to use for BigQuery queries. If not provided, the project ID will be inferred from the environment.",
+                    "pattern": "^[a-z0-9-]+$"
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -298,6 +298,11 @@
                     "type": "boolean",
                     "default": false,
                     "markdownDescription": "Enable debug logging to help troubleshoot issues. Logs will appear in the 'Dataform Tools' output channel."
+                },
+                "vscode-dataform-tools.bigqueryProjectId": {
+                    "type": "string",
+                    "default": null,
+                    "markdownDescription": "Project ID to use for BigQuery queries. If not provided, the project ID will be inferred from the environment."
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -299,10 +299,10 @@
                     "default": false,
                     "markdownDescription": "Enable debug logging to help troubleshoot issues. Logs will appear in the 'Dataform Tools' output channel."
                 },
-                "vscode-dataform-tools.bigqueryProjectId": {
+                "vscode-dataform-tools.gcpProjectId": {
                     "type": "string",
                     "default": null,
-                    "markdownDescription": "Project ID to use for BigQuery queries. If not provided, the project ID will be inferred from the environment.",
+                    "markdownDescription": "GCP project ID to use for BigQuery queries. When not provided, the project ID will be inferred from your enviroment typically same as `gcloud config list project`",
                     "pattern": "^[a-z0-9-]+$"
                 }
             }

--- a/src/bigqueryClient.ts
+++ b/src/bigqueryClient.ts
@@ -8,7 +8,7 @@ let isAuthenticated: boolean = false;
 
 export async function createBigQueryClient() {
     try {
-        const projectId = vscode.workspace.getConfiguration('vscode-dataform-tools').get('bigqueryProjectId');
+        const projectId = vscode.workspace.getConfiguration('vscode-dataform-tools').get('gcpProjectId');
         // default state will be projectId as null and the projectId will be inferred from what the user has set using gcloud cli
         // @ts-ignore 
         bigquery = new BigQuery({ projectId });

--- a/src/bigqueryClient.ts
+++ b/src/bigqueryClient.ts
@@ -8,7 +8,10 @@ let isAuthenticated: boolean = false;
 
 export async function createBigQueryClient() {
     try {
-        bigquery = new BigQuery();
+        const projectId = vscode.workspace.getConfiguration('vscode-dataform-tools').get('bigqueryProjectId');
+        // default state will be projectId as null and the projectId will be inferred from what the user has set using gcloud cli
+        // @ts-ignore 
+        bigquery = new BigQuery({ projectId });
         await verifyAuthentication();
         vscode.window.showInformationMessage('BigQuery client created successfully.');
     } catch (error) {


### PR DESCRIPTION
Solves: https://github.com/ashish10alex/vscode-dataform-tools/issues/116

- [x] verify user input for project id using regex
- [x] test in windows 
- [x] ensure no regression