### PR TITLE
fix: data preview cannot render struct types

### DIFF
--- a/media/js/showQueryResults.js
+++ b/media/js/showQueryResults.js
@@ -155,7 +155,7 @@ window.addEventListener('message', event => {
 
         new Tabulator("#bigqueryResults", {
             layout: "fitDataFill",
-            height: "100%",
+            height: "calc(100vh - 200px)",
             data:results,
             columns:columns,
             // autoColumns:true,

--- a/src/bigqueryRunQuery.ts
+++ b/src/bigqueryRunQuery.ts
@@ -4,6 +4,10 @@ import { QueryResultsOptions } from '@google-cloud/bigquery';
 import { bigQuerytimeoutMs } from './constants';
 import { formatBytes } from './utils';
 
+let bigQueryJob: any;
+let cancelBigQueryJobSignal = false;
+let queryLimit = 1000;
+
 // Function to recursively extract values from nested objects and handle Big objects
 const extractValue: any = (value: any) => {
     if (typeof value === 'object' && value !== null) {
@@ -190,8 +194,11 @@ export async function queryBigQuery(query: string) {
                 if (Array.isArray(value) && ((value[0] && typeof value[0] === "string") || (value.length === 0) || (value[0] && Object.keys(value[0])[0] === "value"))) {
                     value = convertArrayToObject(value, key);
                 } else if (typeof value === "object" && !Array.isArray(value) && value !== null) {
-                    const structValues = [value];
-                    value = structValues;
+                    Object.entries(value).forEach(([fieldName, fieldValue]) => {
+                        const fullFieldName = `${key}_x_${fieldName}`;
+                        obj[fullFieldName] = fieldValue;
+                    });
+                    return;
                 }
 
                 let _childrens: any = [];

--- a/src/bigqueryRunQuery.ts
+++ b/src/bigqueryRunQuery.ts
@@ -187,9 +187,11 @@ export async function queryBigQuery(query: string) {
         Object.entries(row).forEach(([key, value]: [any, any]) => {
             //TODO:  Handling nested BigQuery rows. This if statement might not be robust
             if (typeof (value) === "object" && value !== null && !["Big", "BigQueryDate", "BigQueryDatetime", "BigQueryTime", "BigQueryTimestamp", "BigQueryRange", "BigQueryInt"].includes(value?.constructor?.name)) {
-
-                if ((value[0] && typeof value[0] === "string") || (value.length === 0) || Object.keys(value[0])[0] === "value") {
+                if (Array.isArray(value) && ((value[0] && typeof value[0] === "string") || (value.length === 0) || (value[0] && Object.keys(value[0])[0] === "value"))) {
                     value = convertArrayToObject(value, key);
+                } else if (typeof value === "object" && !Array.isArray(value) && value !== null) {
+                    const structValues = [value];
+                    value = structValues;
                 }
 
                 let _childrens: any = [];


### PR DESCRIPTION
Solves: https://github.com/ashish10alex/vscode-dataform-tools/issues/125

- [x] Column data shows without any errors
- [x] Test in windows 
- [x] Ensure no regression 

we will be using `x` as the separator for struct column as using `.`  is resulting in no data being shown when using Tabulator

Test query

```sql
SELECT
  11 as qty,
  STRUCT(
    'HELLO WORLD 1' as field_1,
    'HELLO WORLD 2' as field_2
  ) as hello,
      "my_data" as foo,
      id,
      ARRAY<STRING>['string1', 'string2', 'string3'] AS StringArray,
      ARRAY(
        SELECT AS STRUCT * FROM UNNEST([]) AS EmptyArrayCol
      ) AS EmptyArray,
      ARRAY(
        SELECT AS STRUCT * FROM UNNEST([]) AS AnotherEmptyArrayCol
      ) AS AnotherEmptyArrayCol,
      ARRAY(
        SELECT AS STRUCT * FROM UNNEST(GENERATE_ARRAY(1, 3)) AS PopulatedArrayCol
      ) AS PopulatedArray,
      ARRAY(
        SELECT AS STRUCT * FROM UNNEST(GENERATE_ARRAY(1, 5)) AS PopulatedArrayMoreItems
      ) AS PopulatedArrayMoreItems,
      ARRAY(
        SELECT AS STRUCT * FROM UNNEST(GENERATE_DATE_ARRAY(CURRENT_DATE(), CURRENT_DATE() + 6, INTERVAL 1 day)) AS dateArray
      ) AS dateArray,
    FROM UNNEST(GENERATE_ARRAY(1, 2)) AS id
```

Output in BigQuery ui 
![CleanShot 2025-03-20 at 20 51 45@2x](https://github.com/user-attachments/assets/750dab43-59e5-4a93-b37b-66f182d08f55)


Output in the extension 

![CleanShot 2025-03-20 at 20 52 47@2x](https://github.com/user-attachments/assets/8d530302-4fcf-4cdf-922c-5bf1909dc9b1)
