### PR TITLE
feat: make multiple views/tables query visible from a single .js file

### DIFF
--- a/media/js/showCompiledQuery.js
+++ b/media/js/showCompiledQuery.js
@@ -247,7 +247,7 @@ window.addEventListener('message', event => {
     const dependents = event?.data?.dependents;
     const models = event?.data?.models;
     const lineageMetadata = event?.data?.lineageMetadata;
-    let modelLastUpdateTime = event?.data?.modelLastUpdateTime;
+    let modelsLastUpdateTimesMeta = event?.data?.modelsLastUpdateTimesMeta;
     if (models){
 
         let targetTablesOrViews = event?.data?.targetTablesOrViews;
@@ -256,17 +256,19 @@ window.addEventListener('message', event => {
             targetTableOrViewLink.style.display = "";
             
             let linksHtml = '';
-            for (const targetTableOrView of targetTablesOrViews) {
+            for (const [index, targetTableOrView] of targetTablesOrViews.entries()) {
                 const modelName = `${targetTableOrView.target.database}.${targetTableOrView.target.schema}.${targetTableOrView.target.name}`;
                 const modelUrl = getUrlToNavigateToTableInBigQuery(targetTableOrView.target.database, targetTableOrView.target.schema, targetTableOrView.target.name);
                 fullModelName = modelName;
 
-                if (modelLastUpdateTime) {
+                if (modelsLastUpdateTimesMeta) {
+                    const modelLastUpdateTime = modelsLastUpdateTimesMeta[index]?.lastModifiedTime;
+                    const modelWasUpdatedToday = modelsLastUpdateTimesMeta[index]?.modelWasUpdatedToday;
                     linksHtml += `
                         <div>
-                            <span class="modified-time ${event?.data?.modelWasUpdatedToday === false ? 'outdated' : ''}" 
-                                    title="Last modified: ${event?.data?.modelLastUpdateTime}">
-                                <small>Last modified: ${event?.data?.modelLastUpdateTime}</small>
+                            <span class="modified-time ${modelWasUpdatedToday === false ? 'outdated' : ''}" 
+                                    title="Last modified: ${modelLastUpdateTime || 'n/a'}">
+                                <small>Last modified: ${modelLastUpdateTime || 'n/a'}</small>
                             </span><br>
                             <div style="display: flex; align-items: center; gap: 8px;">
                                 <a href="${modelUrl}">${modelName}</a>

--- a/src/types.ts
+++ b/src/types.ts
@@ -295,7 +295,7 @@ export type LastModifiedTimeMeta = {
     error: {
         message: string | undefined,
     }
-};
+}[];
 
 
 export type DependancyModelMetadata = {

--- a/src/views/register-preview-compiled-panel.ts
+++ b/src/views/register-preview-compiled-panel.ts
@@ -415,9 +415,9 @@ export class CompiledQueryPanel {
             return;
         }
 
-        const [dryRunResults, modelLastUpdateTimeMeta] = await Promise.all([
+        const [dryRunResults, modelsLastUpdateTimesMeta] = await Promise.all([
             dryRunAndShowDiagnostics(curFileMeta, queryAutoCompMeta, curFileMeta.document, diagnosticCollection, false),
-            getModelLastModifiedTime(targetTablesOrViews[0].target.database, targetTablesOrViews[0].target.schema, targetTablesOrViews[0].target.name)
+            getModelLastModifiedTime(targetTablesOrViews.map((table) => table.target))
         ]);
         const [dryRunResult, preOpsDryRunResult, postOpsDryRunResult] = dryRunResults;
 
@@ -496,8 +496,7 @@ export class CompiledQueryPanel {
                 "models": curFileMeta.fileMetadata.tables,
                 "dependents": curFileMeta.dependents,
                 "dataformTags": dataformTags,
-                "modelLastUpdateTime": modelLastUpdateTimeMeta.lastModifiedTime,
-                "modelWasUpdatedToday": modelLastUpdateTimeMeta.modelWasUpdatedToday,
+                "modelsLastUpdateTimesMeta": modelsLastUpdateTimesMeta
             });
             this._cachedResults = { fileMetadata, curFileMeta, targetTablesOrViews, errorMessage, dryRunStat, location};
             declarationsAndTargets = queryAutoCompMeta.declarationsAndTargets;


### PR DESCRIPTION
Solve: https://github.com/ashish10alex/vscode-dataform-tools/issues/128

**Tests**

- [x] Make all queries created by .js file visible in compiled query area 
- [x] Able to show multiple models produced by single file and also show their update times 
- [x] Test in windows
- [x] Ensure compiled query preview for .sqlx file types are unaffected