### PR TITLE
feat: remove redundant active model metadata parsing

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1187,7 +1187,7 @@ export async function dryRunAndShowDiagnostics(curFileMeta:any,  document:vscode
 
     if (!showCompiledQueryInVerticalSplitOnSave) {
         let combinedTableIds = "";
-        curFileMeta.fileMetadata.tables.forEach((table: { target: { database: string; schema: string; name: string; }; }) => {
+        curFileMeta.fileMetadata.tables.forEach((table: { target: Target }) => {
             let targetTableId = ` ${table.target.database}.${table.target.schema}.${table.target.name} ; `;
             combinedTableIds += targetTableId;
         });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1131,24 +1131,26 @@ export async function dryRunAndShowDiagnostics(curFileMeta:any,  document:vscode
 
     let queryToDryRun = "";
     const type = curFileMeta.fileMetadata.queryMeta.type ;
+    const fileMetadata = curFileMeta.fileMetadata;
+
     if (type === "table" || type === "view") {
-        let preOpsQuery = curFileMeta.fileMetadata.queryMeta.preOpsQuery;
+        let preOpsQuery = fileMetadata.queryMeta.preOpsQuery;
         if(preOpsQuery && preOpsQuery !== ""){
             preOpsQuery = replaceQueryLabelWtEmptyStringForDryRun(preOpsQuery);
         }
-        queryToDryRun = preOpsQuery + curFileMeta.fileMetadata.queryMeta.tableOrViewQuery;
+        queryToDryRun = preOpsQuery + fileMetadata.queryMeta.tableOrViewQuery;
     } else if (type === "assertion") {
-        queryToDryRun = curFileMeta.fileMetadata.queryMeta.assertionQuery;
+        queryToDryRun = fileMetadata.queryMeta.assertionQuery;
     } else if (type === "operations") {
-        queryToDryRun = curFileMeta.fileMetadata.queryMeta.preOpsQuery + curFileMeta.fileMetadata.queryMeta.operationsQuery;
+        queryToDryRun = fileMetadata.queryMeta.preOpsQuery + fileMetadata.queryMeta.operationsQuery;
     } else if (type === "incremental") {
         //TODO: defaulting to using incremental query to dry run for now
         // let nonIncrementalQuery = currFileMetadata.queryMeta.preOpsQuery + currFileMetadata.queryMeta.nonIncrementalQuery;
-        let preOpsQuery = curFileMeta.fileMetadata.queryMeta.incrementalPreOpsQuery.trimStart();
+        let preOpsQuery = fileMetadata.queryMeta.incrementalPreOpsQuery.trimStart();
         if(preOpsQuery && preOpsQuery !== ""){
-            preOpsQuery = replaceQueryLabelWtEmptyStringForDryRun(curFileMeta.fileMetadata.queryMeta.preOpsQuery);
+            preOpsQuery = replaceQueryLabelWtEmptyStringForDryRun(fileMetadata.queryMeta.preOpsQuery);
         }
-        let incrementalQuery = preOpsQuery + curFileMeta.fileMetadata.queryMeta.incrementalQuery.trimStart();
+        let incrementalQuery = preOpsQuery + fileMetadata.queryMeta.incrementalQuery.trimStart();
         queryToDryRun = incrementalQuery;
     }
 
@@ -1156,8 +1158,8 @@ export async function dryRunAndShowDiagnostics(curFileMeta:any,  document:vscode
     let [dryRunResult, preOpsDryRunResult, postOpsDryRunResult] = await Promise.all([
         queryDryRun(queryToDryRun),
         //TODO: If pre_operations block has an error the diagnostics wont be placed at correct place in main query block
-        queryDryRun(curFileMeta.fileMetadata.queryMeta.preOpsQuery),
-        queryDryRun(curFileMeta.fileMetadata.queryMeta.postOpsQuery)
+        queryDryRun(fileMetadata.queryMeta.preOpsQuery),
+        queryDryRun(fileMetadata.queryMeta.postOpsQuery)
     ]);
 
     compiledQuerySchema = dryRunResult.schema;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1103,7 +1103,7 @@ export async function gatherQueryAutoCompletionMeta(){
     if (!CACHED_COMPILED_DATAFORM_JSON){
         return;
     }
-    // all 3 of these together take less than 0.35ms (Dataform repository with 285 nodes)
+    // all 2 of these together take approx less than 0.35ms (Dataform repository with 285 nodes)
     let [declarationsAndTargets, dataformTags] = await Promise.all([
         getDependenciesAutoCompletionItems(CACHED_COMPILED_DATAFORM_JSON),
         getDataformTags(CACHED_COMPILED_DATAFORM_JSON),

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1099,18 +1099,17 @@ export function handleSemicolonPrePostOps(fileMetadata: TablesWtFullQuery){
     return fileMetadata;
 }
 
-export async function gatherQueryAutoCompletionMeta(curFileMeta:any){
+export async function gatherQueryAutoCompletionMeta(){
     if (!CACHED_COMPILED_DATAFORM_JSON){
         return;
     }
     // all 3 of these together take less than 0.35ms (Dataform repository with 285 nodes)
-    let [declarationsAndTargets, dataformTags, currFileMetadata] = await Promise.all([
+    let [declarationsAndTargets, dataformTags] = await Promise.all([
         getDependenciesAutoCompletionItems(CACHED_COMPILED_DATAFORM_JSON),
         getDataformTags(CACHED_COMPILED_DATAFORM_JSON),
-        getQueryMetaForCurrentFile(curFileMeta.pathMeta.relativeFilePath, CACHED_COMPILED_DATAFORM_JSON)
     ]);
     return {
-        declarationsAndTargets: declarationsAndTargets, dataformTags: dataformTags, currFileMetadata: currFileMetadata
+        declarationsAndTargets: declarationsAndTargets, dataformTags: dataformTags
     };
 
 }
@@ -1119,7 +1118,7 @@ function replaceQueryLabelWtEmptyStringForDryRun(query:string) {
     return query.replace(/SET\s+@@query_label\s*=\s*(['"]).*?\1\s*;/gi, '');
 }
 
-export async function dryRunAndShowDiagnostics(curFileMeta:any, queryAutoCompMeta:any, document:vscode.TextDocument, diagnosticCollection:any, showCompiledQueryInVerticalSplitOnSave:boolean|undefined){
+export async function dryRunAndShowDiagnostics(curFileMeta:any,  document:vscode.TextDocument, diagnosticCollection:any, showCompiledQueryInVerticalSplitOnSave:boolean|undefined){
     let sqlxBlockMetadata: SqlxBlockMetadata | undefined = undefined;
     //NOTE: Currently inline diagnostics are only supported for .sqlx files
     if (curFileMeta.pathMeta.extension === "sqlx") {
@@ -1130,27 +1129,26 @@ export async function dryRunAndShowDiagnostics(curFileMeta:any, queryAutoCompMet
         showCompiledQueryInVerticalSplitOnSave = vscode.workspace.getConfiguration('vscode-dataform-tools').get('showCompiledQueryInVerticalSplitOnSave');
     }
 
-    let currFileMetadata = handleSemicolonPrePostOps(queryAutoCompMeta.currFileMetadata);
-
     let queryToDryRun = "";
-    if (currFileMetadata.queryMeta.type === "table" || currFileMetadata.queryMeta.type === "view") {
-        let preOpsQuery = currFileMetadata.queryMeta.preOpsQuery;
+    const type = curFileMeta.fileMetadata.queryMeta.type ;
+    if (type === "table" || type === "view") {
+        let preOpsQuery = curFileMeta.fileMetadata.queryMeta.preOpsQuery;
         if(preOpsQuery && preOpsQuery !== ""){
             preOpsQuery = replaceQueryLabelWtEmptyStringForDryRun(preOpsQuery);
         }
-        queryToDryRun = preOpsQuery + currFileMetadata.queryMeta.tableOrViewQuery;
-    } else if (currFileMetadata.queryMeta.type === "assertion") {
-        queryToDryRun = currFileMetadata.queryMeta.assertionQuery;
-    } else if (currFileMetadata.queryMeta.type === "operations") {
-        queryToDryRun = currFileMetadata.queryMeta.preOpsQuery + currFileMetadata.queryMeta.operationsQuery;
-    } else if (currFileMetadata.queryMeta.type === "incremental") {
+        queryToDryRun = preOpsQuery + curFileMeta.fileMetadata.queryMeta.tableOrViewQuery;
+    } else if (type === "assertion") {
+        queryToDryRun = curFileMeta.fileMetadata.queryMeta.assertionQuery;
+    } else if (type === "operations") {
+        queryToDryRun = curFileMeta.fileMetadata.queryMeta.preOpsQuery + curFileMeta.fileMetadata.queryMeta.operationsQuery;
+    } else if (type === "incremental") {
         //TODO: defaulting to using incremental query to dry run for now
         // let nonIncrementalQuery = currFileMetadata.queryMeta.preOpsQuery + currFileMetadata.queryMeta.nonIncrementalQuery;
-        let preOpsQuery = currFileMetadata.queryMeta.incrementalPreOpsQuery.trimStart();
+        let preOpsQuery = curFileMeta.fileMetadata.queryMeta.incrementalPreOpsQuery.trimStart();
         if(preOpsQuery && preOpsQuery !== ""){
-            preOpsQuery = replaceQueryLabelWtEmptyStringForDryRun(currFileMetadata.queryMeta.preOpsQuery);
+            preOpsQuery = replaceQueryLabelWtEmptyStringForDryRun(curFileMeta.fileMetadata.queryMeta.preOpsQuery);
         }
-        let incrementalQuery = preOpsQuery + currFileMetadata.queryMeta.incrementalQuery.trimStart();
+        let incrementalQuery = preOpsQuery + curFileMeta.fileMetadata.queryMeta.incrementalQuery.trimStart();
         queryToDryRun = incrementalQuery;
     }
 
@@ -1158,8 +1156,8 @@ export async function dryRunAndShowDiagnostics(curFileMeta:any, queryAutoCompMet
     let [dryRunResult, preOpsDryRunResult, postOpsDryRunResult] = await Promise.all([
         queryDryRun(queryToDryRun),
         //TODO: If pre_operations block has an error the diagnostics wont be placed at correct place in main query block
-        queryDryRun(currFileMetadata.queryMeta.preOpsQuery),
-        queryDryRun(currFileMetadata.queryMeta.postOpsQuery)
+        queryDryRun(curFileMeta.fileMetadata.queryMeta.preOpsQuery),
+        queryDryRun(curFileMeta.fileMetadata.queryMeta.postOpsQuery)
     ]);
 
     compiledQuerySchema = dryRunResult.schema;
@@ -1171,11 +1169,11 @@ export async function dryRunAndShowDiagnostics(curFileMeta:any, queryAutoCompMet
         }
 
         let offSet = 0;
-        if (currFileMetadata.queryMeta.type === "table" || currFileMetadata.queryMeta.type === "view") {
+        if (type === "table" || type === "view") {
             offSet = tableQueryOffset;
-        } else if (currFileMetadata.queryMeta.type === "assertion") {
+        } else if (type === "assertion") {
             offSet = assertionQueryOffset;
-        } else if (currFileMetadata.queryMeta.type === "incremental") {
+        } else if (type === "incremental") {
             offSet = incrementalTableOffset;
         }
 
@@ -1187,7 +1185,7 @@ export async function dryRunAndShowDiagnostics(curFileMeta:any, queryAutoCompMet
 
     if (!showCompiledQueryInVerticalSplitOnSave) {
         let combinedTableIds = "";
-        currFileMetadata.tables.forEach((table) => {
+        curFileMeta.fileMetadata.tables.forEach((table: { target: { database: string; schema: string; name: string; }; }) => {
             let targetTableId = ` ${table.target.database}.${table.target.schema}.${table.target.name} ; `;
             combinedTableIds += targetTableId;
         });
@@ -1205,7 +1203,7 @@ export async function compiledQueryWtDryRun(document: vscode.TextDocument, diagn
         return;
     }
 
-    let queryAutoCompMeta = await gatherQueryAutoCompletionMeta(curFileMeta);
+    let queryAutoCompMeta = await gatherQueryAutoCompletionMeta();
     if (!queryAutoCompMeta){
         return;
     }
@@ -1213,7 +1211,7 @@ export async function compiledQueryWtDryRun(document: vscode.TextDocument, diagn
     dataformTags = queryAutoCompMeta.dataformTags;
     declarationsAndTargets = queryAutoCompMeta.declarationsAndTargets;
 
-    dryRunAndShowDiagnostics(curFileMeta, queryAutoCompMeta, document, diagnosticCollection, showCompiledQueryInVerticalSplitOnSave);
+    dryRunAndShowDiagnostics(curFileMeta, document, diagnosticCollection, showCompiledQueryInVerticalSplitOnSave);
 
     return [queryAutoCompMeta.dataformTags, queryAutoCompMeta.declarationsAndTargets];
 }

--- a/src/views/register-preview-compiled-panel.ts
+++ b/src/views/register-preview-compiled-panel.ts
@@ -139,7 +139,7 @@ export class CompiledQueryPanel {
                     return;
                 }
 
-                let queryAutoCompMeta = await gatherQueryAutoCompletionMeta(currentFileMetadata);
+                let queryAutoCompMeta = await gatherQueryAutoCompletionMeta();
                 if (!queryAutoCompMeta){
                     return;
                 }
@@ -151,7 +151,7 @@ export class CompiledQueryPanel {
                     diagnosticCollection.clear();
                 }
                 if (currentFileMetadata.document){
-                    dryRunAndShowDiagnostics(currentFileMetadata, queryAutoCompMeta, currentFileMetadata.document, diagnosticCollection, false);
+                    dryRunAndShowDiagnostics(currentFileMetadata, currentFileMetadata.document, diagnosticCollection, false);
                 }
                 return;
             }
@@ -409,14 +409,14 @@ export class CompiledQueryPanel {
             diagnosticCollection.clear();
         }
 
-        let queryAutoCompMeta = await gatherQueryAutoCompletionMeta(curFileMeta);
+        let queryAutoCompMeta = await gatherQueryAutoCompletionMeta();
         if (!queryAutoCompMeta || !curFileMeta.document || !targetTablesOrViews){
             //TODO: show some error message in this case
             return;
         }
 
         const [dryRunResults, modelsLastUpdateTimesMeta] = await Promise.all([
-            dryRunAndShowDiagnostics(curFileMeta, queryAutoCompMeta, curFileMeta.document, diagnosticCollection, false),
+            dryRunAndShowDiagnostics(curFileMeta, curFileMeta.document, diagnosticCollection, false),
             getModelLastModifiedTime(targetTablesOrViews.map((table) => table.target))
         ]);
         const [dryRunResult, preOpsDryRunResult, postOpsDryRunResult] = dryRunResults;


### PR DESCRIPTION
remove redundant active model metadata parsing. From the tests it does not result in perceivable latency improvement perhaps due to how fast the operation is.  