### PR TITLE
fix: multiple assertions when ran does not show the correctly show failed assertions

### DIFF
--- a/media/js/showQueryResults.js
+++ b/media/js/showQueryResults.js
@@ -231,6 +231,24 @@ function hideQuery(){
     navLinks[0].classList.add('active');
 }
 
+// Function to create a Tabulator table with common configuration
+function createTabulatorTable(elementId, data, columns, options = {}) {
+    const defaultConfig = {
+        layout: "fitDataFill",
+        height: "calc(100vh - 250px)",
+        data: data,
+        columns: columns,
+        pagination: "local",
+        paginationSize: 20,
+        paginationCounter: "rows"
+    };
+
+    return new Tabulator(elementId, {
+        ...defaultConfig,
+        ...options
+    });
+}
+
 window.addEventListener('message', event => {
     const results = event?.data?.results;
     const columns = event?.data?.columns;
@@ -297,15 +315,7 @@ window.addEventListener('message', event => {
         ];
         
         // Create the tabulator table
-        new Tabulator("#multiQueryResults", {
-            layout: "fitDataFill",
-            height: "calc(100vh - 250px)",
-            data: summaryData,
-            columns: columns,
-            pagination: "local",
-            paginationSize: 20,
-            paginationCounter: "rows",
-        });
+        createTabulatorTable("#multiQueryResults", summaryData, columns);
     }
 
     if (bigQueryJobId) {
@@ -337,18 +347,18 @@ window.addEventListener('message', event => {
         // Show the table
         document.getElementById('bigqueryResults').style.display = 'table';
 
-        new Tabulator("#bigqueryResults", {
-            layout: "fitDataFill",
+        createTabulatorTable("#bigqueryResults", results, columns, {
             height: "calc(100vh - 200px)",
-            data: results,
-            columns: columns,
-            // autoColumns:true,
             dataTree: true,
             dataTreeStartExpanded: false,
-            rowHeader: { formatter: "rownum", headerSort: false, hozAlign: "center", resizable: false, frozen: true, width: 60 },
-            pagination: "local",
-            paginationSize: 20,
-            paginationCounter: "rows",
+            rowHeader: { 
+                formatter: "rownum", 
+                headerSort: false, 
+                hozAlign: "center", 
+                resizable: false, 
+                frozen: true, 
+                width: 60 
+            }
         });
     }
 

--- a/media/js/showQueryResults.js
+++ b/media/js/showQueryResults.js
@@ -97,6 +97,24 @@ if (queryLimit){
 }
 
 
+// Function to get the column definitions for the summary table
+function getSummaryTableColumns() {
+    return [
+        {title: "Id", field: "index", headerSort: true, width: 80},
+        {title: "Status", field: "status", headerSort: true, width: 120},
+        {title: "Action", field: "index", formatter: function(cell) {
+            return "<button class='view-result-btn'>View Results</button>";
+        }, cellClick: function(e, cell) {
+            if (e.target.classList.contains('view-result-btn')) {
+                const rowData = cell.getRow().getData();
+                requestSelectedResultFromMultiResultTable(rowData.index);
+                showNavLinks();
+            }
+        }, headerSort: false, width: 160},
+        {title: "Query", field: "query", headerSort: true, width: 2500}
+    ];
+}
+
 // Add event listener for the Back to Summary button
 const backToSummaryButton = document.getElementById('backToSummaryButton');
 if (backToSummaryButton) {
@@ -120,26 +138,11 @@ if (backToSummaryButton) {
         
         // Recreate the summary table if needed
         if (currentSummaryData) {
-            const columns = [
-                {title: "Id", field: "index", headerSort: true, width: 80},
-                {title: "Status", field: "status", headerSort: true, width: 120},
-                {title: "Action", field: "index", formatter: function(cell) {
-                    return "<button class='view-result-btn'>View Results</button>";
-                }, cellClick: function(e, cell) {
-                    if (e.target.classList.contains('view-result-btn')) {
-                        const rowData = cell.getRow().getData();
-                        requestSelectedResultFromMultiResultTable(rowData.index);
-                        showNavLinks();
-                    }
-                }, headerSort: false, width: 160},
-                {title: "Query", field: "query", headerSort: true, width: 2500},
-            ];
-            
             new Tabulator("#multiQueryResults", {
                 layout: "fitDataFill",
                 height: "calc(100vh - 250px)",
                 data: currentSummaryData,
-                columns: columns,
+                columns: getSummaryTableColumns(),
                 pagination: "local",
                 paginationSize: 20,
                 paginationCounter: "rows",
@@ -298,24 +301,8 @@ window.addEventListener('message', event => {
         // Store summary data for later use
         currentSummaryData = summaryData;
         
-        // Create columns for the summary table - removed Query column as requested
-        const columns = [
-            {title: "Id", field: "index", headerSort: true, width: 80},
-            {title: "Status", field: "status", headerSort: true, width: 120},
-            {title: "Action", field: "index", formatter: function(cell) {
-                return "<button class='view-result-btn'>View Results</button>";
-            }, cellClick: function(e, cell) {
-                if (e.target.classList.contains('view-result-btn')) {
-                    const rowData = cell.getRow().getData();
-                    requestSelectedResultFromMultiResultTable(rowData.index);
-                    showNavLinks();
-                }
-            }, headerSort: false, width: 160},
-            {title: "Query", field: "query", headerSort: true, width: 2500}
-        ];
-        
         // Create the tabulator table
-        createTabulatorTable("#multiQueryResults", summaryData, columns);
+        createTabulatorTable("#multiQueryResults", summaryData, getSummaryTableColumns());
     }
 
     if (bigQueryJobId) {

--- a/media/js/showQueryResults.js
+++ b/media/js/showQueryResults.js
@@ -111,8 +111,6 @@ if (queryLimit){
     });
 }
 
-
-// Function to get the column definitions for the summary table
 function getSummaryTableColumns() {
     return [
         {title: "Id", field: "index", headerSort: true, width: 80},
@@ -130,7 +128,6 @@ function getSummaryTableColumns() {
     ];
 }
 
-// Add event listener for the Back to Summary button
 const backToSummaryButton = document.getElementById('backToSummaryButton');
 if (backToSummaryButton) {
     backToSummaryButton.addEventListener('click', function() {
@@ -222,21 +219,6 @@ function requestSelectedResultFromMultiResultTable(resultIndex) {
         command: 'viewResultDetail',
         resultIndex: resultIndex
     });
-}
-
-function handleShowQueryClick(query) {
-    // Set the SQL content
-    document.getElementById("sqlCodeBlock").textContent = query;
-
-    // Switch to code view
-    document.getElementById("resultBlock").style.display = "none";
-    document.getElementById("multiResultsBlock").style.display = "none";
-    document.getElementById("codeBlock").style.display = "";
-    
-    // Update the nav links to show the code tab as active
-    const navLinks = document.querySelectorAll('.topnav a');
-    navLinks.forEach(link => link.classList.remove('active'));
-    navLinks[1].classList.add('active');
 }
 
 function hideQuery(){

--- a/media/js/showQueryResults.js
+++ b/media/js/showQueryResults.js
@@ -128,7 +128,7 @@ if (backToSummaryButton) {
                 }, cellClick: function(e, cell) {
                     if (e.target.classList.contains('view-result-btn')) {
                         const rowData = cell.getRow().getData();
-                        handleViewResultClick(rowData.index);
+                        requestSelectedResultFromMultiResultTable(rowData.index);
                         showNavLinks();
                     }
                 }, headerSort: false, width: 160},
@@ -185,12 +185,12 @@ function postRunCleanup(){
     document.getElementById("cancelBigQueryJobButton").disabled = true;
 }
 
-function handleViewResultClick(resultIndex) {
+function requestSelectedResultFromMultiResultTable(resultIndex) {
     // Clear any previous results first
     document.getElementById('bigqueryResults').innerHTML = '';
+    document.getElementById('bigqueryerror').textContent = '';
     document.getElementById('noResultsDiv').style.display = 'none';
     document.getElementById('errorsDiv').style.display = 'none';
-    document.getElementById('bigqueryerror').textContent = '';
     
     // Show the back button
     document.getElementById('backToSummaryDiv').style.display = 'block';
@@ -289,7 +289,7 @@ window.addEventListener('message', event => {
             }, cellClick: function(e, cell) {
                 if (e.target.classList.contains('view-result-btn')) {
                     const rowData = cell.getRow().getData();
-                    handleViewResultClick(rowData.index);
+                    requestSelectedResultFromMultiResultTable(rowData.index);
                     showNavLinks();
                 }
             }, headerSort: false, width: 160},

--- a/media/js/showQueryResults.js
+++ b/media/js/showQueryResults.js
@@ -67,15 +67,11 @@ if (cancelBigQueryJobButton){
     });
 }
 
-const queryLimit = document.getElementById('queryLimit');
-if (queryLimit){
-    document.getElementById("queryLimit").addEventListener("change", function() {
-    var selectedValue = this.value;
-    vscode.postMessage({
-        command: 'queryLimit',
-        value: selectedValue
-    });
-    });
+function clearLoadingMessage() {
+    if (loadingMessage && document.body.contains(loadingMessage)) {
+        document.body.removeChild(loadingMessage);
+    }
+    loadingMessage = undefined;
 }
 
 function hideNavLinks(){
@@ -87,6 +83,19 @@ function showNavLinks(){
     navLinks[0].style.display = '';
     navLinks[1].style.display = '';
 }
+
+
+const queryLimit = document.getElementById('queryLimit');
+if (queryLimit){
+    document.getElementById("queryLimit").addEventListener("change", function() {
+    var selectedValue = this.value;
+    vscode.postMessage({
+        command: 'queryLimit',
+        value: selectedValue
+    });
+    });
+}
+
 
 // Add event listener for the Back to Summary button
 const backToSummaryButton = document.getElementById('backToSummaryButton');
@@ -108,7 +117,6 @@ if (backToSummaryButton) {
         
         // Show multi-results view
         document.getElementById('multiResultsBlock').style.display = 'block';
-        console.log("currentSummaryData", currentSummaryData);
         
         // Recreate the summary table if needed
         if (currentSummaryData) {
@@ -169,13 +177,6 @@ if (bigQueryResults){
 let timerInterval = undefined;
 let elapsedTime = 0;
 let loadingMessage = undefined;
-
-function clearLoadingMessage() {
-    if (loadingMessage && document.body.contains(loadingMessage)) {
-        document.body.removeChild(loadingMessage);
-    }
-    loadingMessage = undefined;
-}
 
 function postRunCleanup(){
     clearInterval(timerInterval);

--- a/media/js/showQueryResults.js
+++ b/media/js/showQueryResults.js
@@ -113,7 +113,8 @@ if (backToSummaryButton) {
         // Recreate the summary table if needed
         if (currentSummaryData) {
             const columns = [
-                {title: "Assertion check", field: "status", headerSort: true, width: 120},
+                {title: "Id", field: "index", headerSort: true, width: 80},
+                {title: "Status", field: "status", headerSort: true, width: 120},
                 {title: "Action", field: "index", formatter: function(cell) {
                     return "<button class='view-result-btn'>View Results</button>";
                 }, cellClick: function(e, cell) {
@@ -122,7 +123,8 @@ if (backToSummaryButton) {
                         handleViewResultClick(rowData.index);
                         showNavLinks();
                     }
-                }, headerSort: false, width: 120}
+                }, headerSort: false, width: 160},
+                {title: "Query", field: "query", headerSort: true, width: 2500},
             ];
             
             new Tabulator("#multiQueryResults", {
@@ -279,7 +281,8 @@ window.addEventListener('message', event => {
         
         // Create columns for the summary table - removed Query column as requested
         const columns = [
-            {title: "Assertion check", field: "status", headerSort: true, width: 120},
+            {title: "Id", field: "index", headerSort: true, width: 80},
+            {title: "Status", field: "status", headerSort: true, width: 120},
             {title: "Action", field: "index", formatter: function(cell) {
                 return "<button class='view-result-btn'>View Results</button>";
             }, cellClick: function(e, cell) {
@@ -288,7 +291,8 @@ window.addEventListener('message', event => {
                     handleViewResultClick(rowData.index);
                     showNavLinks();
                 }
-            }, headerSort: false, width: 120}
+            }, headerSort: false, width: 160},
+            {title: "Query", field: "query", headerSort: true, width: 2500}
         ];
         
         // Create the tabulator table

--- a/media/js/showQueryResults.js
+++ b/media/js/showQueryResults.js
@@ -99,6 +99,16 @@ function showNavLinks(){
     navLinks[1].style.display = '';
 }
 
+function hideQuery(){
+    document.getElementById("sqlCodeBlock").textContent = '';
+    document.getElementById("resultBlock").style.display = "block";
+    document.getElementById("multiResultsBlock").style.display = "block";
+    document.getElementById("codeBlock").style.display = "none";
+    const navLinks = document.querySelectorAll('.topnav a');
+    navLinks.forEach(link => link.classList.remove('active'));
+    navLinks[0].classList.add('active');
+}
+
 
 const queryLimit = document.getElementById('queryLimit');
 if (queryLimit){
@@ -219,16 +229,6 @@ function requestSelectedResultFromMultiResultTable(resultIndex) {
         command: 'viewResultDetail',
         resultIndex: resultIndex
     });
-}
-
-function hideQuery(){
-    document.getElementById("sqlCodeBlock").textContent = '';
-    document.getElementById("resultBlock").style.display = "block";
-    document.getElementById("multiResultsBlock").style.display = "block";
-    document.getElementById("codeBlock").style.display = "none";
-    const navLinks = document.querySelectorAll('.topnav a');
-    navLinks.forEach(link => link.classList.remove('active'));
-    navLinks[0].classList.add('active');
 }
 
 // Function to create a Tabulator table with common configuration

--- a/media/js/showQueryResults.js
+++ b/media/js/showQueryResults.js
@@ -2,6 +2,21 @@ const vscode = acquireVsCodeApi();
 
 let incrementalCheckBoxDiv =  document.getElementById("incrementalCheckBoxDiv");
 
+function createLoadingMessage(){
+    // Create a loading message element
+    loadingMessageDiv = document.createElement('div');
+    loadingMessageDiv.id = 'loading-message';
+    loadingMessageDiv.textContent = 'Loading data...';
+    loadingMessageDiv.style.cssText = `
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        font-size: 12px;
+    `;
+    return loadingMessageDiv;
+}
+
 const checkbox = document.getElementById('incrementalCheckbox');
 checkbox.addEventListener('change', function() {
     if (this.checked) {
@@ -68,10 +83,10 @@ if (cancelBigQueryJobButton){
 }
 
 function clearLoadingMessage() {
-    if (loadingMessage && document.body.contains(loadingMessage)) {
-        document.body.removeChild(loadingMessage);
+    if (loadingMessageDiv && document.body.contains(loadingMessageDiv)) {
+        document.body.removeChild(loadingMessageDiv);
     }
-    loadingMessage = undefined;
+    loadingMessageDiv = undefined;
 }
 
 function hideNavLinks(){
@@ -179,7 +194,7 @@ if (bigQueryResults){
 
 let timerInterval = undefined;
 let elapsedTime = 0;
-let loadingMessage = undefined;
+let loadingMessageDiv = undefined;
 
 function postRunCleanup(){
     clearInterval(timerInterval);
@@ -391,31 +406,21 @@ window.addEventListener('message', event => {
         
         // Clear any existing loading message first
         clearLoadingMessage();
+        let loadingMessageDiv = createLoadingMessage();
         
-        // Create a loading message element
-        loadingMessage = document.createElement('div');
-        loadingMessage.id = 'loading-message';
-        loadingMessage.textContent = 'Loading data...';
-        loadingMessage.style.cssText = `
-            position: absolute;
-            top: 50%;
-            left: 50%;
-            transform: translate(-50%, -50%);
-            font-size: 12px;
-        `;
-
         let startTime = Date.now();
 
         function updateLoadingMessage() {
             elapsedTime = Math.floor((Date.now() - startTime) / 1000);
-            if (loadingMessage) {
-                loadingMessage.textContent = `Loading data... (${elapsedTime} seconds)`;
+            if (loadingMessageDiv) {
+                loadingMessageDiv.textContent = `Loading data... (${elapsedTime} seconds)`;
             }
             return elapsedTime;
         }
+    
 
         elapsedTime = updateLoadingMessage();
         timerInterval = setInterval(updateLoadingMessage, 1000);
-        document.body.appendChild(loadingMessage);
+        document.body.appendChild(loadingMessageDiv);
     }
 });

--- a/media/js/showQueryResults.js
+++ b/media/js/showQueryResults.js
@@ -93,6 +93,7 @@ const backToSummaryButton = document.getElementById('backToSummaryButton');
 if (backToSummaryButton) {
     backToSummaryButton.addEventListener('click', function() {
         hideQuery();
+        hideNavLinks();
         // Hide the back button
         document.getElementById('backToSummaryDiv').style.display = 'none';
         

--- a/media/js/showQueryResults.js
+++ b/media/js/showQueryResults.js
@@ -249,6 +249,18 @@ function createTabulatorTable(elementId, data, columns, options = {}) {
     });
 }
 
+function clearHighlighting(element) {
+    if (element) {
+        // Remove highlight.js classes
+        element.className = element.className.replace(/hljs\S*/g, '');
+        // Remove data-highlighted attribute
+        element.removeAttribute('data-highlighted');
+        // Remove any copy buttons
+        const copyButtons = element.parentElement?.querySelectorAll('.hljs-copy-button');
+        copyButtons?.forEach(button => button.remove());
+    }
+}
+
 window.addEventListener('message', event => {
     const results = event?.data?.results;
     const columns = event?.data?.columns;
@@ -371,8 +383,10 @@ window.addEventListener('message', event => {
     }
 
     if (query){
-        document.getElementById("sqlCodeBlock").textContent = query;
-        hljs.addPlugin( new CopyButtonPlugin({
+        const sqlCodeBlock = document.getElementById("sqlCodeBlock");
+        clearHighlighting(sqlCodeBlock);
+        sqlCodeBlock.textContent = query;
+        hljs.addPlugin(new CopyButtonPlugin({
             autohide: false, // Always show the copy button
         }));
         hljs.highlightAll();

--- a/media/js/showQueryResults.js
+++ b/media/js/showQueryResults.js
@@ -131,7 +131,7 @@ if (backToSummaryButton) {
         
         // Clear any displayed data
         document.getElementById('bigqueryResults').innerHTML = '';
-        document.getElementById('bigqueryerror').textContent = '';
+        document.getElementById('bigqueryError').textContent = '';
         
         // Show multi-results view
         document.getElementById('multiResultsBlock').style.display = 'block';
@@ -191,7 +191,7 @@ function postRunCleanup(){
 function requestSelectedResultFromMultiResultTable(resultIndex) {
     // Clear any previous results first
     document.getElementById('bigqueryResults').innerHTML = '';
-    document.getElementById('bigqueryerror').textContent = '';
+    document.getElementById('bigqueryError').textContent = '';
     document.getElementById('noResultsDiv').style.display = 'none';
     document.getElementById('errorsDiv').style.display = 'none';
     
@@ -279,7 +279,7 @@ window.addEventListener('message', event => {
        incrementalCheckBoxDiv.style.display = "none";
     }
 
-    // Handle multiple query results
+    // Handle multiple query results, currently only used to separate multiple assertions queries
     if (multiResults && summaryData) {
         hideQuery();
         hideNavLinks();
@@ -383,7 +383,7 @@ window.addEventListener('message', event => {
 
     if (errorMessage){
         postRunCleanup();
-        document.getElementById('bigqueryerror').textContent = errorMessage;
+        document.getElementById('bigqueryError').textContent = errorMessage;
     }
 
     if (showLoadingMessage){

--- a/media/js/showQueryResults.js
+++ b/media/js/showQueryResults.js
@@ -101,7 +101,7 @@ if (backToSummaryButton) {
         // Recreate the summary table if needed
         if (currentSummaryData) {
             const columns = [
-                {title: "Status", field: "status", headerSort: true, width: 120},
+                {title: "Assertion check", field: "status", headerSort: true, width: 120},
                 {title: "Action", field: "index", formatter: function(cell) {
                     return "<button class='view-result-btn'>View Results</button>";
                 }, cellClick: function(e, cell) {
@@ -239,7 +239,7 @@ window.addEventListener('message', event => {
         
         // Create columns for the summary table - removed Query column as requested
         const columns = [
-            {title: "Status", field: "status", headerSort: true, width: 120},
+            {title: "Assertion check", field: "status", headerSort: true, width: 120},
             {title: "Action", field: "index", formatter: function(cell) {
                 return "<button class='view-result-btn'>View Results</button>";
             }, cellClick: function(e, cell) {

--- a/media/js/showQueryResults.js
+++ b/media/js/showQueryResults.js
@@ -197,7 +197,7 @@ window.addEventListener('message', event => {
     const noResults = event?.data?.noResults;
     const jobCostMeta = jobStats?.jobCostMeta;
     const bigQueryJobEndTime = jobStats?.bigQueryJobEndTime;
-    const bigQueryJobId = jobStats?.bigQueryJobId || event?.data?.bigQueryJobId;
+    const bigQueryJobId =  event?.data?.bigQueryJobId || jobStats?.bigQueryJobId;
     const bigQueryJobCancelled = event?.data?.bigQueryJobCancelled;
     const errorMessage = event?.data?.errorMessage;
     const query = event?.data?.query;
@@ -262,13 +262,14 @@ window.addEventListener('message', event => {
         });
     }
 
+    if (bigQueryJobId) {
+        updateBigQueryJobLink(bigQueryJobId);
+    }
+
     if (results && columns) {
         document.getElementById("runQueryButton").disabled = false;
         document.getElementById("cancelBigQueryJobButton").disabled = true;
         updateDateTime(elapsedTime, jobCostMeta, bigQueryJobEndTime);
-        if (bigQueryJobId) {
-            updateBigQueryJobLink(bigQueryJobId);
-        }
         clearInterval(timerInterval);
         clearLoadingMessage();
 

--- a/media/js/showQueryResults.js
+++ b/media/js/showQueryResults.js
@@ -82,6 +82,7 @@ if (queryLimit){
 const backToSummaryButton = document.getElementById('backToSummaryButton');
 if (backToSummaryButton) {
     backToSummaryButton.addEventListener('click', function() {
+        hideQuery();
         // Hide the back button
         document.getElementById('backToSummaryDiv').style.display = 'none';
         
@@ -190,6 +191,34 @@ function handleViewResultClick(resultIndex) {
     });
 }
 
+function handleShowQueryClick(query) {
+    // Set the SQL content
+    document.getElementById("sqlCodeBlock").textContent = query;
+    
+    // Highlight the code
+    hljs.highlightElement(document.getElementById("sqlCodeBlock"));
+    
+    // Switch to code view
+    document.getElementById("resultBlock").style.display = "none";
+    document.getElementById("multiResultsBlock").style.display = "none";
+    document.getElementById("codeBlock").style.display = "";
+    
+    // Update the nav links to show the code tab as active
+    const navLinks = document.querySelectorAll('.topnav a');
+    navLinks.forEach(link => link.classList.remove('active'));
+    navLinks[1].classList.add('active');
+}
+
+function hideQuery(){
+    document.getElementById("sqlCodeBlock").textContent = '';
+    document.getElementById("resultBlock").style.display = "block";
+    document.getElementById("multiResultsBlock").style.display = "block";
+    document.getElementById("codeBlock").style.display = "none";
+    const navLinks = document.querySelectorAll('.topnav a');
+    navLinks.forEach(link => link.classList.remove('active'));
+    navLinks[0].classList.add('active');
+}
+
 window.addEventListener('message', event => {
     const results = event?.data?.results;
     const columns = event?.data?.columns;
@@ -219,6 +248,7 @@ window.addEventListener('message', event => {
 
     // Handle multiple query results
     if (multiResults && summaryData) {
+        hideQuery();
         document.getElementById("runQueryButton").disabled = false;
         document.getElementById("cancelBigQueryJobButton").disabled = true;
         clearInterval(timerInterval);

--- a/media/js/showQueryResults.js
+++ b/media/js/showQueryResults.js
@@ -78,6 +78,16 @@ if (queryLimit){
     });
 }
 
+function hideNavLinks(){
+    navLinks[0].style.display = 'none';
+    navLinks[1].style.display = 'none';
+}
+
+function showNavLinks(){
+    navLinks[0].style.display = '';
+    navLinks[1].style.display = '';
+}
+
 // Add event listener for the Back to Summary button
 const backToSummaryButton = document.getElementById('backToSummaryButton');
 if (backToSummaryButton) {
@@ -109,6 +119,7 @@ if (backToSummaryButton) {
                     if (e.target.classList.contains('view-result-btn')) {
                         const rowData = cell.getRow().getData();
                         handleViewResultClick(rowData.index);
+                        showNavLinks();
                     }
                 }, headerSort: false, width: 120}
             ];
@@ -194,10 +205,7 @@ function handleViewResultClick(resultIndex) {
 function handleShowQueryClick(query) {
     // Set the SQL content
     document.getElementById("sqlCodeBlock").textContent = query;
-    
-    // Highlight the code
-    hljs.highlightElement(document.getElementById("sqlCodeBlock"));
-    
+
     // Switch to code view
     document.getElementById("resultBlock").style.display = "none";
     document.getElementById("multiResultsBlock").style.display = "none";
@@ -249,6 +257,7 @@ window.addEventListener('message', event => {
     // Handle multiple query results
     if (multiResults && summaryData) {
         hideQuery();
+        hideNavLinks();
         document.getElementById("runQueryButton").disabled = false;
         document.getElementById("cancelBigQueryJobButton").disabled = true;
         clearInterval(timerInterval);
@@ -276,6 +285,7 @@ window.addEventListener('message', event => {
                 if (e.target.classList.contains('view-result-btn')) {
                     const rowData = cell.getRow().getData();
                     handleViewResultClick(rowData.index);
+                    showNavLinks();
                 }
             }, headerSort: false, width: 120}
         ];

--- a/src/views/register-query-results-panel.ts
+++ b/src/views/register-query-results-panel.ts
@@ -161,9 +161,6 @@ export class CustomViewProvider implements vscode.WebviewViewProvider {
                 index,
                 status,
                 query: meta.query,
-                results: meta.results,
-                columns: meta.columns,
-                jobStats: meta.jobStats
               };
             });
             

--- a/src/views/register-query-results-panel.ts
+++ b/src/views/register-query-results-panel.ts
@@ -156,7 +156,7 @@ export class CustomViewProvider implements vscode.WebviewViewProvider {
             
             // Prepare summary data for the multi-results table
             const summaryData = resultsMetadata.map((meta, index) => {
-              const status = meta.errorMessage ? 'Failed' : (meta.results && meta.results.length > 0) ? 'Success' : 'No results';
+              const status = meta.errorMessage ? 'Failed' : (meta.results && meta.results.length > 0) ? '❌' : '✅';
               return { 
                 index,
                 status,

--- a/src/views/register-query-results-panel.ts
+++ b/src/views/register-query-results-panel.ts
@@ -281,7 +281,7 @@ export class CustomViewProvider implements vscode.WebviewViewProvider {
       </div>
 
       <div id="multiResultsBlock" style="display: none;">
-        <h3>Multiple Query Results</h3>
+        <h3>Assertion Checks</h3>
         <table id="multiQueryResults" class="display" width="100%"></table>
       </div>
 

--- a/src/views/register-query-results-panel.ts
+++ b/src/views/register-query-results-panel.ts
@@ -295,7 +295,7 @@ export class CustomViewProvider implements vscode.WebviewViewProvider {
       </div>
 
       <div id="resultBlock" style="height: 400px;">
-        <p  style="color: red"><span id="bigqueryerror"></span></p>
+        <p  style="color: red"><span id="bigqueryError"></span></p>
         <table id="bigqueryResults" class="display" width="100%"></table>
       </div>
 

--- a/src/views/register-query-results-panel.ts
+++ b/src/views/register-query-results-panel.ts
@@ -135,7 +135,12 @@ export class CustomViewProvider implements vscode.WebviewViewProvider {
           this._view.webview.html = this._getHtmlForWebview(this._view.webview);
           this._view.webview.postMessage({"showLoadingMessage": true, "incrementalCheckBox": incrementalCheckBox });
           this._view.show(true);
-          const allQueries = query.trim().split(";").filter(q => q.trim());
+          let allQueries = [];
+          if(type === "assertion"){
+            allQueries = query.trim().split(";").filter(q => q.trim());
+          } else {
+            allQueries = [query];
+          }
           let resultsMetadata = [];
           
           for (let i = 0; i < allQueries.length; i++) {


### PR DESCRIPTION
Fixes: https://github.com/ashish10alex/vscode-dataform-tools/issues/131

- [x] refactor run query in BigQuery function to have separate section to retrieve results and process them for tabulator api
- [x] only split using ";" if the type of query ran is an assertion 
- [x] ui component to show navigate multiple query results 
- [x] refactor code to avoid redundant code 
- [x] test in windows 
- [x] ensure no regression 
- [x] Highlighting gets messed up when trying to switch between multiple result items. This is not a critical feature so we might not solve this. 

Results of running multiple assertions will show as follows. Clicking "View Results" shows you the table with the results from the assertions if it has failed. If the assertion has passed, there will be assertion passed banner. Also, you can see the query the assertion was ran with in both failure and passing cases. 

![CleanShot 2025-03-25 at 21 49 48@2x](https://github.com/user-attachments/assets/4311856f-9d3a-42fa-8917-d10ef4128b60)
