### PR TITLE
fix: unnested struct columns not showing in results preview

### DIFF
--- a/src/bigqueryRunQuery.ts
+++ b/src/bigqueryRunQuery.ts
@@ -29,11 +29,11 @@ const extractValue: any = (value: any) => {
     return value;
 };
 
-function parseObject(obj: any, _childrens: any) {
+function parseObject(key:any, obj: any, _childrens: any) {
     // Check if obj is an array of primitive values
     if (Array.isArray(obj) && obj.length > 0 && (typeof obj[0] !== 'object' || obj[0] === null)) {
         obj.forEach((value) => {
-            _childrens.push({ value });
+            _childrens.push({ [key]: value });
         });
         return _childrens;
     }
@@ -65,7 +65,7 @@ function parseObject(obj: any, _childrens: any) {
                     });
                 } else {
                     // Handle arrays of objects as before
-                    let new_children = parseObject(value, _childrens);
+                    let new_children = parseObject(key, value, _childrens);
                     if (new_children.constructor.name === "Array") {
                         new_children.forEach((_: any, idx: any) => {
                             new_children[idx] = transformBigValues(new_children[idx]);
@@ -228,7 +228,7 @@ export async function queryBigQuery(query: string): Promise<{results: any[] | un
                 }
 
                 let _childrens: any = [];
-                _childrens = parseObject(value, _childrens);
+                _childrens = parseObject(key, value, _childrens);
 
                 // Nested object in Tabulator are displayed by adding the key _children to the exsisting array
                 if (obj._children) {

--- a/src/bigqueryRunQuery.ts
+++ b/src/bigqueryRunQuery.ts
@@ -30,6 +30,14 @@ const extractValue: any = (value: any) => {
 };
 
 function parseObject(obj: any, _childrens: any) {
+    // Check if obj is an array of primitive values
+    if (Array.isArray(obj) && obj.length > 0 && (typeof obj[0] !== 'object' || obj[0] === null)) {
+        obj.forEach((value) => {
+            _childrens.push({ value });
+        });
+        return _childrens;
+    }
+    
     let _children: any = {};
     Object.entries(obj).forEach(([key, value]: [any, any]) => {
         if (typeof value === 'object' && value !== null) {
@@ -50,12 +58,20 @@ function parseObject(obj: any, _childrens: any) {
 
             }
             else if (value.constructor.name === 'Array') {
-                let new_children = parseObject(value, _childrens);
-                if (new_children.constructor.name === "Array") {
-                    new_children.forEach((_: any, idx: any) => {
-                        new_children[idx] = transformBigValues(new_children[idx]);
-                        new_children[idx] = { ..._children, ...new_children[idx] };
+                // Handle arrays of primitive values directly
+                if (value.length > 0 && (typeof value[0] !== 'object' || value[0] === null)) {
+                    value.forEach((item: any) => {
+                        _childrens.push({ ..._children, [key]: item });
                     });
+                } else {
+                    // Handle arrays of objects as before
+                    let new_children = parseObject(value, _childrens);
+                    if (new_children.constructor.name === "Array") {
+                        new_children.forEach((_: any, idx: any) => {
+                            new_children[idx] = transformBigValues(new_children[idx]);
+                            new_children[idx] = { ..._children, ...new_children[idx] };
+                        });
+                    }
                 }
             }
             else {

--- a/src/bigqueryRunQuery.ts
+++ b/src/bigqueryRunQuery.ts
@@ -64,7 +64,6 @@ function parseObject(key:any, obj: any, _childrens: any) {
                         _childrens.push({ ..._children, [key]: item });
                     });
                 } else {
-                    // Handle arrays of objects as before
                     let new_children = parseObject(key, value, _childrens);
                     if (new_children.constructor.name === "Array") {
                         new_children.forEach((_: any, idx: any) => {


### PR DESCRIPTION
Test query that needs to pass 

```sql
config {
  type: 'operations',
  name: "test2"
}

SELECT
      11 as qty,
      STRUCT(
        'HELLO WORLD 1' as field_1,
        'HELLO WORLD 2' as field_2
      ) as t_struct,
      "my_data" as t_string,
      name,
      laps,
      times,
      ARRAY<STRING>['string1', 'string2', 'string3'] AS StringArray,
      ARRAY(
        SELECT AS STRUCT * FROM UNNEST([]) AS EmptyArrayCol
      ) AS EmptyArray,
      ARRAY(
        SELECT AS STRUCT * FROM UNNEST(GENERATE_ARRAY(1, 3)) AS PopulatedArrayCol
      ) AS PopulatedArray,
      ARRAY(
        SELECT AS STRUCT * FROM UNNEST(GENERATE_ARRAY(1, 5)) AS PopulatedArrayMoreItems
      ) AS PopulatedArrayMoreItems,
      ARRAY(
        SELECT AS STRUCT * FROM UNNEST(GENERATE_DATE_ARRAY(CURRENT_DATE(), CURRENT_DATE() + 6, INTERVAL 1 day)) AS dateArray
      ) AS dateArray,
    FROM 
      UNNEST(
        [
          STRUCT(1 as id, "Murphy" AS name, [23.9, 26.0, 27.0, 26.0] AS laps, [10, 20, 30] as times),
          STRUCT(2 as id, "Bosse" AS name, [23.6, 26.2, 26.5, 27.1] AS laps, [10, 20, 30] as times)
        ]
      ) AS Murphy
```



![CleanShot 2025-04-06 at 11 39 43@2x](https://github.com/user-attachments/assets/39b66892-1187-402c-aa4d-054be223824f)
