### PR TITLE
fix: incorrect termination of pre-orations when comment is present

### DIFF
--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -557,7 +557,7 @@ suite('format bytes from dry run in human readable format', () => {
     });
 });
 
-suite.only('handleSemicolonPrePostOps', () => {
+suite('handleSemicolonPrePostOps', () => {
 
     test(`Termination of different preOps e.g. there is new line at the end of the query
          , no semicolons on the end or if the query is empty`, () => {

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert';
 import path from 'path';
 import * as vscode from 'vscode';
-import { compileDataform, formatBytes, getQueryMetaForCurrentFile } from '../../utils';
+import { compileDataform, formatBytes, getQueryMetaForCurrentFile, handleSemicolonPrePostOps } from '../../utils';
 import { DataformCompiledJson } from '../../types';
 import { getMetadataForSqlxFileBlocks } from '../../sqlxFileParser';
 import { tableQueryOffset } from '../../constants';
@@ -555,4 +555,33 @@ suite('format bytes from dry run in human readable format', () => {
         assert.strictEqual(formatBytes(1500), '1.46 KB');
         assert.strictEqual(formatBytes(1024 * 1024 * 1.5), '1.50 MB');
     });
+});
+
+suite.only('handleSemicolonPrePostOps', () => {
+
+    test(`Termination of different preOps e.g. there is new line at the end of the query
+         , no semicolons on the end or if the query is empty`, () => {
+        const fileMetadata = {
+            tables: [],
+            queryMeta: {
+                preOpsQuery: "SELECT 1\n\n",
+                incrementalPreOpsQuery: "SELECT 2;",
+                postOpsQuery: "",
+                type: "",
+                tableOrViewQuery: "",
+                nonIncrementalQuery: "",
+                incrementalQuery: "",
+                assertionQuery: "",
+                operationsQuery: "",
+                error: "",
+            }
+        };
+
+        const result = handleSemicolonPrePostOps(fileMetadata as any);
+
+        assert.strictEqual(result.queryMeta.preOpsQuery, "SELECT 1;\n");
+        assert.strictEqual(result.queryMeta.incrementalPreOpsQuery, "SELECT 2;");
+        assert.strictEqual(result.queryMeta.postOpsQuery, "");
+    });
+
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1215,15 +1215,15 @@ export function handleSemicolonPrePostOps(fileMetadata: TablesWtFullQuery){
     const postOpsEndsWithSemicolon = /;\s*$/.test(fileMetadata.queryMeta.postOpsQuery);
 
     if(!preOpsEndsWithSemicolon && fileMetadata.queryMeta.preOpsQuery !== "" ){
-        fileMetadata.queryMeta.preOpsQuery = fileMetadata.queryMeta.preOpsQuery + ";";
+        fileMetadata.queryMeta.preOpsQuery = fileMetadata.queryMeta.preOpsQuery.trimEnd() + ";" + "\n";
     }
 
     if(!icrementalPreOpsEndsWithSemicolon && fileMetadata.queryMeta.incrementalPreOpsQuery !== "" ){
-        fileMetadata.queryMeta.incrementalPreOpsQuery = fileMetadata.queryMeta.incrementalPreOpsQuery + ";";
+        fileMetadata.queryMeta.incrementalPreOpsQuery = fileMetadata.queryMeta.incrementalPreOpsQuery.trimEnd() + ";" + "\n";
     }
 
     if(!postOpsEndsWithSemicolon && fileMetadata.queryMeta.postOpsQuery !== "" ){
-        fileMetadata.queryMeta.postOpsQuery = fileMetadata.queryMeta.postOpsQuery + ";";
+        fileMetadata.queryMeta.postOpsQuery = fileMetadata.queryMeta.postOpsQuery.trimEnd() + ";" + "\n";
     }
     return fileMetadata;
 }


### PR DESCRIPTION
Fixes: https://github.com/ashish10alex/vscode-dataform-tools/issues/160

Testing:

- [x] MVP of the fix
- [x] Ensure, through some tests that existing parsing is not affected 
- [x] Test in windows 
- [x] Ensure no regression 


**Error:**

![CleanShot 2025-06-13 at 19 11 12@2x](https://github.com/user-attachments/assets/ad4cff67-b16e-4e4f-beba-75ec7a98a20a)

**Fixed**
![CleanShot 2025-06-13 at 19 11 59@2x](https://github.com/user-attachments/assets/f63c290a-1505-4120-afa1-5cb750f666fe)


