### PR TITLE
feat: command to create a new Dataform project

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
             "dependencies": {
                 "@google-cloud/bigquery": "^7.8.0",
                 "@google-cloud/lineage": "^1.3.0",
+                "@google-cloud/resource-manager": "^6.2.0",
                 "@xyflow/react": "^12.4.3",
                 "clean": "^4.0.2",
                 "comment-parser": "^1.4.1",
@@ -1095,10 +1096,201 @@
                 "node": ">=14"
             }
         },
+        "node_modules/@google-cloud/resource-manager": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/@google-cloud/resource-manager/-/resource-manager-6.2.0.tgz",
+            "integrity": "sha512-8acGxhahIxVpmhhgXUAUtLGzUR6WJCuoN9ubmtQRYd2eX78rx3t0F8NS7k3bsBcwVFo1KIC4WkAmFRkZ4JJIwQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "google-gax": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@google-cloud/resource-manager/node_modules/agent-base": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6.0.0"
+            }
+        },
+        "node_modules/@google-cloud/resource-manager/node_modules/gaxios": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.1.tgz",
+            "integrity": "sha512-Odju3uBUJyVCkW64nLD4wKLhbh93bh6vIg/ZIXkWiLPBrdgtc65+tls/qml+un3pr6JqYVFDZbbmLDQT68rTOQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "extend": "^3.0.2",
+                "https-proxy-agent": "^7.0.1",
+                "node-fetch": "^3.3.2"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@google-cloud/resource-manager/node_modules/gcp-metadata": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-7.0.1.tgz",
+            "integrity": "sha512-UcO3kefx6dCcZkgcTGgVOTFb7b1LlQ02hY1omMjjrrBzkajRMCFgYOjs7J71WqnuG1k2b+9ppGL7FsOfhZMQKQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "gaxios": "^7.0.0",
+                "google-logging-utils": "^1.0.0",
+                "json-bigint": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@google-cloud/resource-manager/node_modules/google-auth-library": {
+            "version": "10.2.1",
+            "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.2.1.tgz",
+            "integrity": "sha512-HMxFl2NfeHYnaL1HoRIN1XgorKS+6CDaM+z9LSSN+i/nKDDL4KFFEWogMXu7jV4HZQy2MsxpY+wA5XIf3w410A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "base64-js": "^1.3.0",
+                "ecdsa-sig-formatter": "^1.0.11",
+                "gaxios": "^7.0.0",
+                "gcp-metadata": "^7.0.0",
+                "google-logging-utils": "^1.0.0",
+                "gtoken": "^8.0.0",
+                "jws": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@google-cloud/resource-manager/node_modules/google-gax": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-5.0.1.tgz",
+            "integrity": "sha512-I8fTFXvIG8tYpiDxDXwCXoFsTVsvHJ2GA7DToH+eaRccU8r3nqPMFghVb2GdHSVcu4pq9ScRyB2S1BjO+vsa1Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@grpc/grpc-js": "^1.12.6",
+                "@grpc/proto-loader": "^0.7.13",
+                "abort-controller": "^3.0.0",
+                "duplexify": "^4.1.3",
+                "google-auth-library": "^10.1.0",
+                "google-logging-utils": "^1.1.1",
+                "node-fetch": "^3.3.2",
+                "object-hash": "^3.0.0",
+                "proto3-json-serializer": "^3.0.0",
+                "protobufjs": "^7.5.3",
+                "retry-request": "^8.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@google-cloud/resource-manager/node_modules/gtoken": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
+            "integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
+            "license": "MIT",
+            "dependencies": {
+                "gaxios": "^7.0.0",
+                "jws": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@google-cloud/resource-manager/node_modules/http-proxy-agent": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+            "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+            "license": "MIT",
+            "dependencies": {
+                "@tootallnate/once": "2",
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/@google-cloud/resource-manager/node_modules/node-fetch": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+            "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+            "license": "MIT",
+            "dependencies": {
+                "data-uri-to-buffer": "^4.0.0",
+                "fetch-blob": "^3.1.4",
+                "formdata-polyfill": "^4.0.10"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/node-fetch"
+            }
+        },
+        "node_modules/@google-cloud/resource-manager/node_modules/proto3-json-serializer": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-3.0.1.tgz",
+            "integrity": "sha512-Rug90pDIefARAG9MgaFjd0yR/YP4bN3Fov00kckXMjTZa0x86c4WoWfCQFdSeWi9DvRXjhfLlPDIvODB5LOTfg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "protobufjs": "^7.4.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@google-cloud/resource-manager/node_modules/retry-request": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-8.0.1.tgz",
+            "integrity": "sha512-5sR3yWYODO2MTxsKjbCYFQUiXTbAe+83BV8NOB97lz6AS790OBQRUnPxT3SpxNYHUKNnYPwalk1UxuaALLJ77Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/request": "^2.48.13",
+                "extend": "^3.0.2",
+                "teeny-request": "^10.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@google-cloud/resource-manager/node_modules/teeny-request": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-10.1.0.tgz",
+            "integrity": "sha512-3ZnLvgWF29jikg1sAQ1g0o+lr5JX6sVgYvfUJazn7ZjJroDBUTWp44/+cFVX0bULjv4vci+rBD+oGVAkWqhUbw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "http-proxy-agent": "^5.0.0",
+                "https-proxy-agent": "^5.0.0",
+                "node-fetch": "^3.3.2",
+                "stream-events": "^1.0.5"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@google-cloud/resource-manager/node_modules/teeny-request/node_modules/https-proxy-agent": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
         "node_modules/@grpc/grpc-js": {
-            "version": "1.12.4",
-            "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.12.4.tgz",
-            "integrity": "sha512-NBhrxEWnFh0FxeA0d//YP95lRFsSx2TNLEUQg4/W+5f/BMxcCjgOOIT24iD+ZB/tZw057j44DaIxja7w4XMrhg==",
+            "version": "1.13.4",
+            "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.13.4.tgz",
+            "integrity": "sha512-GsFaMXCkMqkKIvwCQjCrwH+GHbPKBjhwo/8ZuUkWHqbI73Kky9I+pQltrlT0+MWpedCoosda53lgjYfyEPgxBg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@grpc/proto-loader": "^0.7.13",
@@ -1937,14 +2129,15 @@
             }
         },
         "node_modules/@types/request": {
-            "version": "2.48.12",
-            "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.12.tgz",
-            "integrity": "sha512-G3sY+NpsA9jnwm0ixhAFQSJ3Q9JkpLZpJbI3GMv0mIAT0y3mRabYeINzal5WOChIiaTEGQYlHOKgkaM9EisWHw==",
+            "version": "2.48.13",
+            "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.13.tgz",
+            "integrity": "sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==",
+            "license": "MIT",
             "dependencies": {
                 "@types/caseless": "*",
                 "@types/node": "*",
                 "@types/tough-cookie": "*",
-                "form-data": "^2.5.0"
+                "form-data": "^2.5.5"
             }
         },
         "node_modules/@types/stack-utils": {
@@ -2695,6 +2888,19 @@
                 "node": ">=14.14.0"
             }
         },
+        "node_modules/call-bind-apply-helpers": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/callsites": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -3225,6 +3431,15 @@
                 "node": ">=0.10"
             }
         },
+        "node_modules/data-uri-to-buffer": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+            "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 12"
+            }
+        },
         "node_modules/debug": {
             "version": "4.3.4",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -3331,6 +3546,20 @@
             "dependencies": {
                 "@babel/runtime": "^7.8.7",
                 "csstype": "^3.0.2"
+            }
+        },
+        "node_modules/dunder-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/duplexify": {
@@ -3451,6 +3680,51 @@
             "license": "MIT",
             "dependencies": {
                 "is-arrayish": "^0.2.1"
+            }
+        },
+        "node_modules/es-define-property": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-object-atoms": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-set-tostringtag": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+            "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.6",
+                "has-tostringtag": "^1.0.2",
+                "hasown": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/esbuild": {
@@ -3871,6 +4145,29 @@
                 "reusify": "^1.0.4"
             }
         },
+        "node_modules/fetch-blob": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+            "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/jimmywarting"
+                },
+                {
+                    "type": "paypal",
+                    "url": "https://paypal.me/jimmywarting"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "node-domexception": "^1.0.0",
+                "web-streams-polyfill": "^3.0.3"
+            },
+            "engines": {
+                "node": "^12.20 || >= 14.13"
+            }
+        },
         "node_modules/file-entry-cache": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -3971,16 +4268,52 @@
             }
         },
         "node_modules/form-data": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
-            "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+            "version": "2.5.5",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.5.tgz",
+            "integrity": "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==",
+            "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.6",
-                "mime-types": "^2.1.12"
+                "combined-stream": "^1.0.8",
+                "es-set-tostringtag": "^2.1.0",
+                "hasown": "^2.0.2",
+                "mime-types": "^2.1.35",
+                "safe-buffer": "^5.2.1"
             },
             "engines": {
                 "node": ">= 0.12"
+            }
+        },
+        "node_modules/form-data/node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/formdata-polyfill": {
+            "version": "4.0.10",
+            "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+            "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+            "license": "MIT",
+            "dependencies": {
+                "fetch-blob": "^3.1.2"
+            },
+            "engines": {
+                "node": ">=12.20.0"
             }
         },
         "node_modules/fraction.js": {
@@ -4094,6 +4427,43 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/get-intrinsic": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.1.1",
+                "function-bind": "^1.1.2",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-symbols": "^1.1.0",
+                "hasown": "^2.0.2",
+                "math-intrinsics": "^1.1.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+            "license": "MIT",
+            "dependencies": {
+                "dunder-proto": "^1.0.1",
+                "es-object-atoms": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/getpass": {
@@ -4212,6 +4582,27 @@
                 "node": ">=14"
             }
         },
+        "node_modules/google-logging-utils": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.1.tgz",
+            "integrity": "sha512-rcX58I7nqpu4mbKztFeOAObbomBbHU2oIb/d3tJfF3dizGSApqtSwYJigGCooHdnMyQBIw8BrWyK96w3YXgr6A==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/gopd": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/graceful-fs": {
             "version": "4.2.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -4276,6 +4667,33 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/has-symbols": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-tostringtag": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+            "license": "MIT",
+            "dependencies": {
+                "has-symbols": "^1.0.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/hasown": {
@@ -5140,6 +5558,15 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/math-intrinsics": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/memoize-one": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
@@ -5470,6 +5897,26 @@
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
             "dev": true
+        },
+        "node_modules/node-domexception": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+            "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+            "deprecated": "Use your platform's native DOMException instead",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/jimmywarting"
+                },
+                {
+                    "type": "github",
+                    "url": "https://paypal.me/jimmywarting"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.5.0"
+            }
         },
         "node_modules/node-fetch": {
             "version": "2.7.0",
@@ -6175,9 +6622,9 @@
             }
         },
         "node_modules/protobufjs": {
-            "version": "7.4.0",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
-            "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
+            "version": "7.5.3",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.3.tgz",
+            "integrity": "sha512-sildjKwVqOI2kmFDiXQ6aEB0fjYTafpEvIBs8tOR8qI4spuL9OPROLVu2qZqi/xgCfsHIwVqlaF8JBjWFHnKbw==",
             "hasInstallScript": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -7551,6 +7998,15 @@
                 "terser": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/web-streams-polyfill": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+            "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 8"
             }
         },
         "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
         "onCommand:extension.runTagWtDeps",
         "onCommand:extension.runTagWtDownstreamDeps",
         "onCommand:extension.runFilesTagsWtOptions",
+        "onCommand:extension.initDataformProject",
         "onCommand:extension.showCompiledQueryInWebView",
         "onCommand:extension.dependencyGraphPanel",
         "onCommand:extension.selectWorkspaceFolder"
@@ -86,6 +87,11 @@
                 "command": "vscode-dataform-tools.runFilesTagsWtOptions",
                 "category": "Dataform",
                 "title": "Run file(s) / tag(s) with options"
+            },
+            {
+                "command": "vscode-dataform-tools.initDataformProject",
+                "category": "Dataform",
+                "title": "Initialize a new Dataform project"
             },
             {
                 "command": "vscode-dataform-tools.runTag",

--- a/package.json
+++ b/package.json
@@ -45,13 +45,14 @@
                 {
                     "id": "queryResultsContainer",
                     "title": "Dataform tools",
-                    "icon": "path/to/icon.svg"
+                    "icon": ""
                 }
             ]
         },
         "views": {
             "queryResultsContainer": [
                 {
+                    "icon": "",
                     "type": "webview",
                     "id": "queryResultsView",
                     "name": "Dataform tools"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "onCommand:extension.runTagWtDeps",
         "onCommand:extension.runTagWtDownstreamDeps",
         "onCommand:extension.runFilesTagsWtOptions",
-        "onCommand:extension.initDataformProject",
+        "onCommand:extension.createNewDataformProject",
         "onCommand:extension.showCompiledQueryInWebView",
         "onCommand:extension.dependencyGraphPanel",
         "onCommand:extension.selectWorkspaceFolder"
@@ -90,9 +90,9 @@
                 "title": "Run file(s) / tag(s) with options"
             },
             {
-                "command": "vscode-dataform-tools.initDataformProject",
+                "command": "vscode-dataform-tools.createNewDataformProject",
                 "category": "Dataform",
-                "title": "Initialize a new Dataform project"
+                "title": "create new Dataform project"
             },
             {
                 "command": "vscode-dataform-tools.runTag",

--- a/package.json
+++ b/package.json
@@ -352,6 +352,7 @@
     "dependencies": {
         "@google-cloud/bigquery": "^7.8.0",
         "@google-cloud/lineage": "^1.3.0",
+        "@google-cloud/resource-manager": "^6.2.0",
         "@xyflow/react": "^12.4.3",
         "clean": "^4.0.2",
         "comment-parser": "^1.4.1",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -107,6 +107,50 @@ export const sqlKeywordsToExcludeFromHoverDefinition = [
   "qualify"
 ];
 
+export const gcloudComputeRegions = [
+  "asia-east1",
+  "asia-east2",
+  "asia-northeast1",
+  "asia-northeast2",
+  "asia-northeast3",
+  "asia-south1",
+  "asia-south2",
+  "asia-southeast1",
+  "asia-southeast2",
+  "australia-southeast1",
+  "australia-southeast2",
+  "europe-central2",
+  "europe-north1",
+  "europe-north2",
+  "europe-southwest1",
+  "europe-west1",
+  "europe-west10",
+  "europe-west12",
+  "europe-west2",
+  "europe-west3",
+  "europe-west4",
+  "europe-west6",
+  "europe-west8",
+  "europe-west9",
+  "me-central1",
+  "me-central2",
+  "me-west1",
+  "northamerica-northeast1",
+  "northamerica-northeast2",
+  "northamerica-south1",
+  "southamerica-east1",
+  "southamerica-west1",
+  "us-central1",
+  "us-east1",
+  "us-east4",
+  "us-east5",
+  "us-south1",
+  "us-west1",
+  "us-west2",
+  "us-west3",
+  "us-west4"
+];
+
 export const cacheDurationMs = 5 * 60 * 1000; // 5 minutes
 
 

--- a/src/createNewDataformProject.ts
+++ b/src/createNewDataformProject.ts
@@ -5,7 +5,7 @@ import { gcloudComputeRegions } from './constants';
 import { ProjectsClient } from '@google-cloud/resource-manager';
 
 
-export async function initDataformProject(){
+export async function createNewDataformProject(){
 
     const projectDir = await openFolderSelector();
     if (!projectDir) {
@@ -48,7 +48,7 @@ export async function initDataformProject(){
     runCommandInTerminal(`${customDataformCliPath} init --project-dir "${projectDir}" --default-database "${gcpProjectId}" --default-location "${defaultLocation}"`);
     // NOTE: wait for half a second before a new vscode workspace at projectDir
     // NOTE: otherwise opening the folder make the terminal command not run as the terminal context is somehow lost
-    await delay(1500); 
+    await delay(2500); 
 
     const folderUri = vscode.Uri.file(path.resolve(projectDir));
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,6 +12,7 @@ import { getWorkspaceFolder, getCurrentFileMetadata, sendNotifactionToUserOnExte
 import { executableIsAvailable } from './utils';
 import { sourcesAutoCompletionDisposable, dependenciesAutoCompletionDisposable, tagsAutoCompletionDisposable, schemaAutoCompletionDisposable } from './completions';
 import { runFilesTagsWtOptions } from './runFilesTagsWtOptions';
+import { initDataformProject } from './initDataformProject';
 import { AssertionRunnerCodeLensProvider, TagsRunnerCodeLensProvider } from './codeLensProvider';
 import { cancelBigQueryJob } from './bigqueryRunQuery';
 import { renameProvider } from './renameProvider';
@@ -204,6 +205,9 @@ export async function activate(context: vscode.ExtensionContext) {
         vscode.commands.registerCommand('vscode-dataform-tools.runFilesTagsWtOptions', runFilesTagsWtOptions)
     );
 
+    context.subscriptions.push(
+        vscode.commands.registerCommand('vscode-dataform-tools.initDataformProject', initDataformProject)
+    );
 
     context.subscriptions.push(
         vscode.languages.registerDocumentFormattingEditProvider('sqlx', {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,7 +12,7 @@ import { getWorkspaceFolder, getCurrentFileMetadata, sendNotifactionToUserOnExte
 import { executableIsAvailable } from './utils';
 import { sourcesAutoCompletionDisposable, dependenciesAutoCompletionDisposable, tagsAutoCompletionDisposable, schemaAutoCompletionDisposable } from './completions';
 import { runFilesTagsWtOptions } from './runFilesTagsWtOptions';
-import { initDataformProject } from './initDataformProject';
+import { createNewDataformProject } from './createNewDataformProject';
 import { AssertionRunnerCodeLensProvider, TagsRunnerCodeLensProvider } from './codeLensProvider';
 import { cancelBigQueryJob } from './bigqueryRunQuery';
 import { renameProvider } from './renameProvider';
@@ -206,7 +206,7 @@ export async function activate(context: vscode.ExtensionContext) {
     );
 
     context.subscriptions.push(
-        vscode.commands.registerCommand('vscode-dataform-tools.initDataformProject', initDataformProject)
+        vscode.commands.registerCommand('vscode-dataform-tools.createNewDataformProject', createNewDataformProject)
     );
 
     context.subscriptions.push(

--- a/src/initDataformProject.ts
+++ b/src/initDataformProject.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { getDataformCliCmdBasedOnScope, isDataformWorkspace, runCommandInTerminal } from "./utils";
+import { delay, getDataformCliCmdBasedOnScope, isDataformWorkspace, runCommandInTerminal } from "./utils";
 import path from 'path';
 import { gcloudComputeRegions } from './constants';
 
@@ -38,10 +38,14 @@ export async function initDataformProject(){
 
     const customDataformCliPath = getDataformCliCmdBasedOnScope(workspaceFolder=projectDir);
     runCommandInTerminal(`${customDataformCliPath} init --project-dir "${projectDir}" --default-database "${gcpProjectId}" --default-location "${defaultLocation}"`);
+    // NOTE: wait for half a second before a new vscode workspace at projectDir
+    // NOTE: otherwise opening the folder make the terminal command not run as the terminal context is somehow lost
+    await delay(1500); 
 
     const folderUri = vscode.Uri.file(path.resolve(projectDir));
 
     await vscode.commands.executeCommand('vscode.openFolder', folderUri, { forceNewWindow: false });
+
 }
 
 async function createInputBox(prompt: string, placeHolder:string, validationErrorMessage: string): Promise<string | undefined> {

--- a/src/initDataformProject.ts
+++ b/src/initDataformProject.ts
@@ -1,0 +1,64 @@
+import * as vscode from 'vscode';
+import { getDataformCliCmdBasedOnScope, isDataformWorkspace, runCommandInTerminal } from "./utils";
+import path from 'path';
+
+
+export async function initDataformProject(){
+
+    let prompt ="Enter the full path for the Dataform project directory";
+    let placeHolder = "/Users/username/path/to/project";
+    let validationErrorMessage = "Path can not be empty";
+    const projectDir = await enterProjectDir(prompt, placeHolder, validationErrorMessage);
+    if (!projectDir) {
+        vscode.window.showInformationMessage("Project directory path not provided, aborting...");
+        return;
+    }
+
+    if(isDataformWorkspace(projectDir)){
+        vscode.window.showErrorMessage(`Directory ${projectDir} is already a Dataform workspace`);
+        return;
+    }
+
+    prompt ="Enter default location";
+    placeHolder = "europe-west2";
+    validationErrorMessage = "Location can not be empty";
+    const defaultLocation = await enterProjectDir(prompt, placeHolder, validationErrorMessage);
+
+    if (!defaultLocation) {
+        vscode.window.showInformationMessage("Default location not provided, aborting...");
+        return;
+    }
+
+    prompt ="Enter GCP project id";
+    placeHolder = "gcp-project-id";
+    validationErrorMessage = "GCP project id can not be empty";
+    const gcpProjectId = await enterProjectDir(prompt, placeHolder, validationErrorMessage);
+
+    if (!gcpProjectId) {
+        vscode.window.showInformationMessage("GCP project id not provided, aborting...");
+        return;
+    }
+
+    const customDataformCliPath = getDataformCliCmdBasedOnScope(workspaceFolder=projectDir);
+    runCommandInTerminal(`${customDataformCliPath} init --project-dir "${projectDir}" --default-database "${gcpProjectId}" --default-location "${defaultLocation}"`);
+
+    const folderUri = vscode.Uri.file(path.resolve(projectDir));
+
+    await vscode.commands.executeCommand('vscode.openFolder', folderUri, { forceNewWindow: false });
+}
+
+async function enterProjectDir(prompt: string, placeHolder:string, validationErrorMessage: string): Promise<string | undefined> {
+    const projectDir = await vscode.window.showInputBox({
+        prompt: prompt,
+        placeHolder: placeHolder,
+        ignoreFocusOut: true,  // keeps the input open if user clicks outside
+        validateInput: (input) => {
+            if (!input || input.trim() === "") {
+                return validationErrorMessage;
+            }
+            return null;
+        }
+    });
+
+    return projectDir;
+}

--- a/src/initDataformProject.ts
+++ b/src/initDataformProject.ts
@@ -5,10 +5,7 @@ import path from 'path';
 
 export async function initDataformProject(){
 
-    let prompt ="Enter the full path for the Dataform project directory";
-    let placeHolder = "/Users/username/path/to/project";
-    let validationErrorMessage = "Path can not be empty";
-    const projectDir = await enterProjectDir(prompt, placeHolder, validationErrorMessage);
+    const projectDir = await openFolderSelector();
     if (!projectDir) {
         vscode.window.showInformationMessage("Project directory path not provided, aborting...");
         return;
@@ -19,9 +16,9 @@ export async function initDataformProject(){
         return;
     }
 
-    prompt ="Enter default location";
-    placeHolder = "europe-west2";
-    validationErrorMessage = "Location can not be empty";
+    let prompt ="Enter default location";
+    let placeHolder = "europe-west2";
+    let validationErrorMessage = "Location can not be empty";
     const defaultLocation = await enterProjectDir(prompt, placeHolder, validationErrorMessage);
 
     if (!defaultLocation) {
@@ -61,4 +58,18 @@ async function enterProjectDir(prompt: string, placeHolder:string, validationErr
     });
 
     return projectDir;
+}
+
+async function openFolderSelector(){
+    const folderUris = await vscode.window.showOpenDialog({
+        canSelectFolders: true,
+        canSelectMany: false,
+        openLabel: "Dataform project folder",
+        canSelectFiles: false // only folders selectable
+    });
+
+    if (folderUris && folderUris.length > 0) {
+        return folderUris[0].fsPath;
+    }
+    return undefined;
 }

--- a/src/initDataformProject.ts
+++ b/src/initDataformProject.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { getDataformCliCmdBasedOnScope, isDataformWorkspace, runCommandInTerminal } from "./utils";
 import path from 'path';
+import { gcloudComputeRegions } from './constants';
 
 
 export async function initDataformProject(){
@@ -16,20 +17,19 @@ export async function initDataformProject(){
         return;
     }
 
-    let prompt ="Enter default location";
-    let placeHolder = "europe-west2";
+    let placeHolder ="Enter default location. E.g. europe-west2";
     let validationErrorMessage = "Location can not be empty";
-    const defaultLocation = await enterProjectDir(prompt, placeHolder, validationErrorMessage);
+    const defaultLocation = await createSelector(gcloudComputeRegions, placeHolder);
 
     if (!defaultLocation) {
         vscode.window.showInformationMessage("Default location not provided, aborting...");
         return;
     }
 
-    prompt ="Enter GCP project id";
+    let prompt ="Enter GCP project id";
     placeHolder = "gcp-project-id";
     validationErrorMessage = "GCP project id can not be empty";
-    const gcpProjectId = await enterProjectDir(prompt, placeHolder, validationErrorMessage);
+    const gcpProjectId = await createInputBox(prompt, placeHolder, validationErrorMessage);
 
     if (!gcpProjectId) {
         vscode.window.showInformationMessage("GCP project id not provided, aborting...");
@@ -44,8 +44,8 @@ export async function initDataformProject(){
     await vscode.commands.executeCommand('vscode.openFolder', folderUri, { forceNewWindow: false });
 }
 
-async function enterProjectDir(prompt: string, placeHolder:string, validationErrorMessage: string): Promise<string | undefined> {
-    const projectDir = await vscode.window.showInputBox({
+async function createInputBox(prompt: string, placeHolder:string, validationErrorMessage: string): Promise<string | undefined> {
+    const inputValue = await vscode.window.showInputBox({
         prompt: prompt,
         placeHolder: placeHolder,
         ignoreFocusOut: true,  // keeps the input open if user clicks outside
@@ -57,8 +57,15 @@ async function enterProjectDir(prompt: string, placeHolder:string, validationErr
         }
     });
 
-    return projectDir;
+    return inputValue;
 }
+
+async function createSelector(selectionItems:string[], placeHolder: string): Promise<string | undefined>{
+     return await vscode.window.showQuickPick(selectionItems, {
+        placeHolder: placeHolder
+    });
+}
+
 
 async function openFolderSelector(){
     const folderUris = await vscode.window.showOpenDialog({

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,6 +15,10 @@ let supportedExtensions = ['sqlx', 'js'];
 
 export let declarationsAndTargets: string[] = [];
 
+export function delay(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
 export function getNonce() {
     let text = "";
     const possible =


### PR DESCRIPTION
Allows the user to create a new Dataform repository via `Dataform: Initialize a new Dataform project` command. On the command invocation user will be prompted to 

1. Select the root directory where Dataform project will be created. If it is already a Dataform project then creation will be aborted
2. Select default location from the list of pre-populated locations. E.g. europe-west2 etc. 
3. Select GCP project Id from list of GCP project Ids available to the user when they have authenticated via gcloud . The list of project ids are populated using [@google-cloud/resource-manager](https://www.npmjs.com/package/@google-cloud/resource-manager) npm package adding to the chunkiness of the vscode extension. 

A new workspace will be opened where the new Dataform project can be explored. 


Tests

- [x] MVP
- [x] consider renaming the command to `create a new Dataform project` 
- [x] Test in windows
- [x] Ensure no regression 