### PR TITLE
feat: enable use of service account key to access bigquery

### DIFF
--- a/package.json
+++ b/package.json
@@ -309,6 +309,11 @@
                     "default": null,
                     "markdownDescription": "GCP project ID to use for BigQuery queries. When not provided, the project ID will be inferred from your enviroment typically same as `gcloud config list project`",
                     "pattern": "^[a-z0-9-]+$"
+                },
+                "vscode-dataform-tools.serviceAccountJsonPath": {
+                    "type": "string",
+                    "default": null,
+                    "markdownDescription": "Path to the json file when the service account exsists"
                 }
             }
         },

--- a/src/bigqueryClient.ts
+++ b/src/bigqueryClient.ts
@@ -9,9 +9,17 @@ let isAuthenticated: boolean = false;
 export async function createBigQueryClient(): Promise<string | undefined> {
     try {
         const projectId = vscode.workspace.getConfiguration('vscode-dataform-tools').get('gcpProjectId');
+        const serviceAccountJsonPath  = vscode.workspace.getConfiguration('vscode-dataform-tools').get('serviceAccountJsonPath');
+
         // default state will be projectId as null and the projectId will be inferred from what the user has set using gcloud cli
+        let options = {projectId};
+        if(serviceAccountJsonPath){
         // @ts-ignore 
-        bigquery = new BigQuery({ projectId });
+            options = {... options , keyFilename: serviceAccountJsonPath}
+        }
+
+        // @ts-ignore 
+        bigquery = new BigQuery(options);
         await verifyAuthentication();
         vscode.window.showInformationMessage('BigQuery client created successfully.');
         return undefined;

--- a/src/hoverProvider.ts
+++ b/src/hoverProvider.ts
@@ -119,7 +119,13 @@ function getHoverOfVariableInJsFileOrBlock(code: string, searchTerm:string): vsc
 async function getTableSchemaAsMarkdown(projectId: string, datasetId:string, tableId:string) {
   try {
 
-  const bigqueryClient = new BigQuery({ projectId });
+    const serviceAccountJsonPath  = vscode.workspace.getConfiguration('vscode-dataform-tools').get('serviceAccountJsonPath');
+    let options = {projectId};
+    if(serviceAccountJsonPath){
+    // @ts-ignore 
+        options = {... options , keyFilename: serviceAccountJsonPath}
+    }
+    const bigqueryClient = new BigQuery(options);
 
     if(bigqueryClient){
 


### PR DESCRIPTION
User will be able to use a service account key for dry runs, data preview by adding the path to json file with the service account key in the vscode settings for Dataform tools extension. Note that this is different from the credentials used by Dataform cli to execute queries which will most likey be the ADC credentials 