### PR TITLE
fix: file extension not correctly inferred when there are multiple periods in the filename

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -786,8 +786,9 @@ export function getFileNameFromDocument(
     showErrorMessage: boolean
 ): FileNameMetadataResult<FileNameMetadata, string> {
     const filePath = document.uri.fsPath;
-    const basenameSplit = path.basename(filePath).split('.');
-    const extension = basenameSplit[1];
+    const extWithDot = path.extname(filePath);
+    const extension = extWithDot.startsWith('.') ? extWithDot.slice(1) : extWithDot;
+    const rawFileName = path.basename(filePath, extWithDot);
     const relativeFilePath = getRelativePath(filePath);
     const validFileType = supportedExtensions.includes(extension);
 
@@ -799,8 +800,6 @@ export function getFileNameFromDocument(
         }
         return { success: false, error: `File type not supported. Supported file types are ${supportedExtensions.join(', ')}` };
     }
-
-    const rawFileName = basenameSplit[0];
     return { success: true, value: [rawFileName, relativeFilePath, extension] };
 }
 


### PR DESCRIPTION
Addresses : https://github.com/ashish10alex/vscode-dataform-tools/issues/192

Extension will show the expected compilation error than the error that the file extension is not one of the supported ones. 

<img width="2622" height="678" alt="CleanShot 2025-10-07 at 11 08 41@2x" src="https://github.com/user-attachments/assets/02dce774-bab5-4f3f-a6c7-b08b946b528d" />
