### PR TITLE
fix: workspace name prefix in file paths in mult-workspace env

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1115,15 +1115,11 @@ export async function getAllFilesWtAnExtension(workspaceFolder: string, extensio
     }
     let files = await vscode.workspace.findFiles(globPattern);
     const fileList = files.map((file) => {
-        if (isRunningOnWindows) {
-            if(trimInitial){
-                const pathParts = vscode.workspace.asRelativePath(file).split(path.win32.sep);
-                return path.win32.normalize(pathParts.slice(1).join(path.win32.sep));
-            }
-            return path.win32.normalize(vscode.workspace.asRelativePath(file));
-        }
         if(trimInitial){
             const pathParts = vscode.workspace.asRelativePath(file).split(path.posix.sep);
+            if(isRunningOnWindows){
+            return path.posix.normalize(pathParts.slice(1).join(path.win32.sep));
+            }
             return path.posix.normalize(pathParts.slice(1).join(path.posix.sep));
         }
         return vscode.workspace.asRelativePath(file);


### PR DESCRIPTION
Fixes: https://github.com/ashish10alex/vscode-dataform-tools/issues/181

Tests: 

- [x] windows
- [x] macOS
- [x] single workspace environment
- [x] multi-workspace environment 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * When multiple workspaces are open, file paths now have the first workspace segment removed and are normalized consistently across Windows and non-Windows systems to improve path formatting in multi-workspace environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->