### PR TITLE
fix: windows path not being correctly infered in single workspace env

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1118,7 +1118,7 @@ export async function getAllFilesWtAnExtension(workspaceFolder: string, extensio
         if(trimInitial){
             const pathParts = vscode.workspace.asRelativePath(file).split(path.posix.sep);
             if(isRunningOnWindows){
-            return path.posix.normalize(pathParts.slice(1).join(path.win32.sep));
+            return path.win32.normalize(pathParts.slice(1).join(path.win32.sep));
             }
             return path.posix.normalize(pathParts.slice(1).join(path.posix.sep));
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows file path handling so file listings consistently use Windows-style separators where applicable, preventing inconsistent path formats across platforms while retaining existing behavior on non-Windows systems.

*✏️ Tip: You can customize this high-level summary in your review settings.*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->