### PR TITLE
fix: parsing of sql block when there are comments above config block

### DIFF
--- a/src/sqlxFileParser.ts
+++ b/src/sqlxFileParser.ts
@@ -57,6 +57,11 @@ export const getMetadataForSqlxFileBlocks = (document: vscode.TextDocument): Sql
                 startOfConfigBlock = i + 1;
                 inMajorBlock = true;
                 
+                // Reset SQL block if we found one before config (likely comments)
+                startOfSqlBlock = 0;
+                endOfSqlBlock = 0;
+                sqlBlockExsists = false;
+                
                 // Single-line block check
                 if (braceDepth === 0) {
                     endOfConfigBlock = i + 1;

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -141,6 +141,34 @@ suite('GetMetadataForSqlxFileBlocks', () => {
             throw error;
         }
     });
+
+    test('Able to parse PARSING.sqlx correctly', async () => {
+        try {
+            const uri = vscode.Uri.file(path.join(workspaceFolder, "definitions/PARSING.sqlx"));
+            let doc = await vscode.workspace.openTextDocument(uri);
+            assert.ok(doc);
+            let sqlxBlockMetadata = getMetadataForSqlxFileBlocks(doc);
+
+            //config block
+            assert.strictEqual(sqlxBlockMetadata.configBlock.startLine, 5, "Config block start line mismatch");
+            assert.strictEqual(sqlxBlockMetadata.configBlock.endLine, 10, "Config block end line mismatch");
+
+            // Pre ops block
+            assert.strictEqual(sqlxBlockMetadata.preOpsBlock.preOpsList.length, 1);
+            assert.strictEqual(sqlxBlockMetadata.preOpsBlock.preOpsList[0].startLine, 21, "Pre ops block start line mismatch");
+            assert.strictEqual(sqlxBlockMetadata.preOpsBlock.preOpsList[0].endLine, 24, "Pre ops block end line mismatch");
+
+            // sql block
+            // The parser includes leading comments in the SQL block if they appear before config, so startLine is 1 (the first comment)
+            assert.strictEqual(sqlxBlockMetadata.sqlBlock.startLine, 1, "SQL block start line mismatch");
+            assert.strictEqual(sqlxBlockMetadata.sqlBlock.endLine, 19, "SQL block end line mismatch");
+
+        } catch (error: any) {
+            console.error('Test failed:', error);
+            vscode.window.showErrorMessage(`Test failed: ${error.message}`);
+            throw error;
+        }
+    });
 });
 
 suite("setDiagnostics", () => {

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -159,8 +159,7 @@ suite('GetMetadataForSqlxFileBlocks', () => {
             assert.strictEqual(sqlxBlockMetadata.preOpsBlock.preOpsList[0].endLine, 24, "Pre ops block end line mismatch");
 
             // sql block
-            // The parser includes leading comments in the SQL block if they appear before config, so startLine is 1 (the first comment)
-            assert.strictEqual(sqlxBlockMetadata.sqlBlock.startLine, 1, "SQL block start line mismatch");
+            assert.strictEqual(sqlxBlockMetadata.sqlBlock.startLine, 13, "SQL block start line mismatch");
             assert.strictEqual(sqlxBlockMetadata.sqlBlock.endLine, 19, "SQL block end line mismatch");
 
         } catch (error: any) {

--- a/src/test/test-workspace/definitions/PARSING.sqlx
+++ b/src/test/test-workspace/definitions/PARSING.sqlx
@@ -1,0 +1,24 @@
+-- First line with some comment
+-- https://github.com/ashish10alex/vscode-dataform-tools
+-- Last line with some comment
+
+config {
+  type: "table",
+  tags: ["tag1", "tag2"],
+  schema: "my_schema",
+  name: "my_table"
+  }
+
+
+SELECT 
+
+"test" as some_column
+FROM
+    ${ref("GAMES")}
+
+-- Another comment
+
+pre_operations {
+  SET
+    @@query_label = "test"
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where configuration block parsing could be affected by previous SQL block definitions, improving accuracy of file parsing.

* **Tests**
  * Added test coverage for SQLX file parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->