### PR TITLE
fix: warning notifications appear even if user has not specified dataform core version in workflow settings

### DIFF
--- a/webviews/preview_compiled/hooks/useVSCodeMessage.ts
+++ b/webviews/preview_compiled/hooks/useVSCodeMessage.ts
@@ -42,6 +42,7 @@ export const useVSCodeMessage = () => {
           nextState.dryRunIncrementalErrorsByNodeType = message.dryRunIncrementalErrorsByNodeType || {};
           nextState.dryRunExpectedOutputErrorsByNodeName = message.dryRunExpectedOutputErrorsByNodeName || {};
           nextState.dryRunExpectedOutputErrorsByNodeType = message.dryRunExpectedOutputErrorsByNodeType || {};
+          nextState.dataformCoreVersion = message.dataformCoreVersion;
           
           if (message.recompiling === true) {
             nextState.compilationTimeMs = undefined;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The Dataform Core version is now correctly propagated in the webview state during recompilation and dry-run processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->