### PR TITLE
Add configuration option to override git repository name

### DIFF
--- a/package.json
+++ b/package.json
@@ -292,6 +292,11 @@
                     "pattern": "^(\\d+[sm])+$",
                     "markdownDescription": "Duration to allow project compilation to complete. Use format like '5m', '60s' etc. Passed to `dataform compile --json --timeout=<value>`"
                 },
+                "vscode-dataform-tools.gitRepoName": {
+                    "type": "string",
+                    "default": "",
+                    "markdownDescription": "Override the repository name used by the extension. When set, this value is used instead of the name derived from the git remote URL or directory name."
+                },
                 "vscode-dataform-tools.formattingCli": {
                     "type": "string",
                     "default": "sqlfluff",

--- a/src/gitClient.ts
+++ b/src/gitClient.ts
@@ -37,6 +37,13 @@ export class GitService {
             // git rev-parse --abbrev-ref HEAD works correctly in worktrees
             const gitBranch = await this.execCmd('git rev-parse --abbrev-ref HEAD') || undefined;
 
+            const overrideRepoName = vscode.workspace.getConfiguration('vscode-dataform-tools').get<string>('gitRepoName');
+            if (overrideRepoName) {
+                logger.info(`Git branch: ${gitBranch}`);
+                logger.info(`Git repo name (override): ${overrideRepoName}`);
+                return { gitBranch, gitRepoName: overrideRepoName };
+            }
+
             let gitRepoName: string | undefined;
             try {
                 const remoteUrl = await this.execCmd('git config --get remote.origin.url');

--- a/src/gitClient.ts
+++ b/src/gitClient.ts
@@ -37,7 +37,10 @@ export class GitService {
             // git rev-parse --abbrev-ref HEAD works correctly in worktrees
             const gitBranch = await this.execCmd('git rev-parse --abbrev-ref HEAD') || undefined;
 
-            const overrideRepoName = vscode.workspace.getConfiguration('vscode-dataform-tools').get<string>('gitRepoName');
+            const overrideRepoName = vscode.workspace
+                .getConfiguration('vscode-dataform-tools')
+                .get<string>('gitRepoName')
+                ?.trim();
             if (overrideRepoName) {
                 logger.info(`Git branch: ${gitBranch}`);
                 logger.info(`Git repo name (override): ${overrideRepoName}`);


### PR DESCRIPTION
## Summary
This PR adds a new configuration option `vscode-dataform-tools.gitRepoName` that allows users to manually override the repository name used by the extension, bypassing the automatic detection from git remote URLs or directory names.

## Key Changes
- Added new VS Code configuration setting `vscode-dataform-tools.gitRepoName` in `package.json` with type `string` and empty default value
- Updated `GitService` in `src/gitClient.ts` to check for the override configuration early in the git information retrieval flow
- When the override is set, the extension logs both the detected git branch and the overridden repository name, then returns immediately without attempting to derive the repo name from git remote or directory

## Implementation Details
- The override check is performed after retrieving the git branch but before attempting to parse the git remote URL
- This ensures the override takes precedence over all automatic detection methods
- The configuration is retrieved using the standard VS Code workspace configuration API
- Appropriate logging is included to help users understand when the override is being applied

https://claude.ai/code/session_01W8E9srFffRBG2RxCWzoju4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new configuration option in VS Code extension settings that allows users to override the repository name automatically detected by the extension. This enhancement provides greater flexibility for repository identification, particularly useful when automatic detection does not align with specific user requirements or project preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->