### PR TITLE
feat(dependency-inspector): wrap long filter conditions

### DIFF
--- a/webviews/components/AutoGrowingTextarea.tsx
+++ b/webviews/components/AutoGrowingTextarea.tsx
@@ -1,0 +1,34 @@
+import { useLayoutEffect, useRef, TextareaHTMLAttributes } from 'react';
+
+type Props = Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, 'value' | 'onChange'> & {
+    value: string;
+    onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+};
+
+export function AutoGrowingTextarea({ value, onChange, ...rest }: Props) {
+    const ref = useRef<HTMLTextAreaElement>(null);
+
+    useLayoutEffect(() => {
+        const el = ref.current;
+        if (!el) { return; }
+        el.style.height = 'auto';
+        el.style.height = `${el.scrollHeight}px`;
+    }, [value]);
+
+    useLayoutEffect(() => {
+        const el = ref.current;
+        if (!el) { return; }
+        let prevWidth = el.clientWidth;
+        const ro = new ResizeObserver(entries => {
+            const width = entries[0].contentRect.width;
+            if (width === prevWidth) { return; }
+            prevWidth = width;
+            el.style.height = 'auto';
+            el.style.height = `${el.scrollHeight}px`;
+        });
+        ro.observe(el);
+        return () => ro.disconnect();
+    }, []);
+
+    return <textarea ref={ref} value={value} onChange={onChange} {...rest} />;
+}

--- a/webviews/dependency-inspector/App.tsx
+++ b/webviews/dependency-inspector/App.tsx
@@ -7,6 +7,7 @@ import StyledSelect, { OptionType } from '../dependancy_graph/components/StyledS
 import { FindWidget } from '../components/FindWidget';
 import DependencyGraph from './DependencyGraph';
 import { BigQueryTableLink } from '../components/BigQueryTableLink';
+import { AutoGrowingTextarea } from '../components/AutoGrowingTextarea';
 
 // ─────────────────────────────────────────────────────────────
 // Helpers
@@ -545,20 +546,9 @@ export default function App() {
                 </div>
                 <div className="flex items-center gap-2">
                     <span className="text-sm text-[var(--vscode-foreground)] whitespace-nowrap">Filter condition</span>
-                    <textarea
+                    <AutoGrowingTextarea
                         value={globalFilter}
                         onChange={e => setGlobalFilter(e.target.value)}
-                        onInput={e => {
-                            const t = e.currentTarget;
-                            t.style.height = 'auto';
-                            t.style.height = `${t.scrollHeight}px`;
-                        }}
-                        ref={el => {
-                            if (el) {
-                                el.style.height = 'auto';
-                                el.style.height = `${el.scrollHeight}px`;
-                            }
-                        }}
                         rows={1}
                         placeholder='e.g. id = "xx" or created_date >= "2024-01-01"'
                         className="flex-1 px-3 py-1.5 text-sm bg-[var(--vscode-input-background)] border border-[var(--vscode-input-border)] text-[var(--vscode-input-foreground)] rounded outline-none focus:ring-1 focus:ring-[var(--vscode-focusBorder)] placeholder:text-[var(--vscode-input-placeholderForeground)] font-mono resize-none whitespace-pre-wrap break-all overflow-hidden"
@@ -695,22 +685,11 @@ export default function App() {
 
                                             {/* Filter Condition */}
                                             <td className="px-4 py-2 align-middle">
-                                                <textarea
+                                                <AutoGrowingTextarea
                                                     value={row.filterCondition}
                                                     onChange={e => {
                                                         if (applyToAll) { return; }
                                                         updateFilterForRow(row.id, e.target.value);
-                                                    }}
-                                                    onInput={e => {
-                                                        const t = e.currentTarget;
-                                                        t.style.height = 'auto';
-                                                        t.style.height = `${t.scrollHeight}px`;
-                                                    }}
-                                                    ref={el => {
-                                                        if (el) {
-                                                            el.style.height = 'auto';
-                                                            el.style.height = `${el.scrollHeight}px`;
-                                                        }
                                                     }}
                                                     readOnly={applyToAll}
                                                     rows={1}

--- a/webviews/dependency-inspector/App.tsx
+++ b/webviews/dependency-inspector/App.tsx
@@ -545,12 +545,23 @@ export default function App() {
                 </div>
                 <div className="flex items-center gap-2">
                     <span className="text-sm text-[var(--vscode-foreground)] whitespace-nowrap">Filter condition</span>
-                    <input
-                        type="text"
+                    <textarea
                         value={globalFilter}
                         onChange={e => setGlobalFilter(e.target.value)}
+                        onInput={e => {
+                            const t = e.currentTarget;
+                            t.style.height = 'auto';
+                            t.style.height = `${t.scrollHeight}px`;
+                        }}
+                        ref={el => {
+                            if (el) {
+                                el.style.height = 'auto';
+                                el.style.height = `${el.scrollHeight}px`;
+                            }
+                        }}
+                        rows={1}
                         placeholder='e.g. id = "xx" or created_date >= "2024-01-01"'
-                        className="flex-1 px-3 py-1.5 text-sm bg-[var(--vscode-input-background)] border border-[var(--vscode-input-border)] text-[var(--vscode-input-foreground)] rounded outline-none focus:ring-1 focus:ring-[var(--vscode-focusBorder)] placeholder:text-[var(--vscode-input-placeholderForeground)] font-mono"
+                        className="flex-1 px-3 py-1.5 text-sm bg-[var(--vscode-input-background)] border border-[var(--vscode-input-border)] text-[var(--vscode-input-foreground)] rounded outline-none focus:ring-1 focus:ring-[var(--vscode-focusBorder)] placeholder:text-[var(--vscode-input-placeholderForeground)] font-mono resize-none whitespace-pre-wrap break-all overflow-hidden"
                     />
                 </div>
             </div>
@@ -684,16 +695,27 @@ export default function App() {
 
                                             {/* Filter Condition */}
                                             <td className="px-4 py-2 align-middle">
-                                                <input
-                                                    type="text"
+                                                <textarea
                                                     value={row.filterCondition}
                                                     onChange={e => {
                                                         if (applyToAll) { return; }
                                                         updateFilterForRow(row.id, e.target.value);
                                                     }}
+                                                    onInput={e => {
+                                                        const t = e.currentTarget;
+                                                        t.style.height = 'auto';
+                                                        t.style.height = `${t.scrollHeight}px`;
+                                                    }}
+                                                    ref={el => {
+                                                        if (el) {
+                                                            el.style.height = 'auto';
+                                                            el.style.height = `${el.scrollHeight}px`;
+                                                        }
+                                                    }}
                                                     readOnly={applyToAll}
+                                                    rows={1}
                                                     placeholder="no filter (full table scan)"
-                                                    className={`w-full px-2 py-1 text-xs font-mono bg-[var(--vscode-input-background)] border border-[var(--vscode-input-border)] text-[var(--vscode-input-foreground)] rounded outline-none focus:ring-1 focus:ring-[var(--vscode-focusBorder)] placeholder:text-[var(--vscode-input-placeholderForeground)] ${applyToAll ? 'opacity-60 cursor-not-allowed' : ''}`}
+                                                    className={`w-full px-2 py-1 text-xs font-mono bg-[var(--vscode-input-background)] border border-[var(--vscode-input-border)] text-[var(--vscode-input-foreground)] rounded outline-none focus:ring-1 focus:ring-[var(--vscode-focusBorder)] placeholder:text-[var(--vscode-input-placeholderForeground)] resize-none whitespace-pre-wrap break-all overflow-hidden ${applyToAll ? 'opacity-60 cursor-not-allowed' : ''}`}
                                                 />
                                             </td>
 


### PR DESCRIPTION
## Summary
- Replace the single-line `<input>` for both global and per-row filter conditions in the Dependency Inspector with auto-growing `<textarea>` elements.
- Long SQL filters (e.g. `REPORT_DATE = CURRENT_DATE() QUALIFY ROW_NUMBER() OVER (...)`) now wrap and remain fully visible instead of being clipped.
- Textareas start at 1 row and expand to fit content on input; `readOnly`, styling, and placeholder behavior preserved.

## Test plan
- [x] Open Dependency Inspector on a model with dependencies.
- [x] Type a long filter into the global filter field — confirm it wraps and the textarea grows.
- [x] With "Apply filter to all dependencies" on, verify per-row filters reflect the global value and are read-only.
- [x] Turn "Apply to all" off and edit a per-row filter with long text — confirm wrap + auto-grow.
- [x] Reload the panel and verify persisted long filters render at the correct height on mount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Added auto-growing multi-line textareas for filter condition inputs across the dependency inspector.

* **Improvements**
  - Single-line inputs replaced with multi-line, auto-resizing fields that preserve existing read‑only/disabled behaviour and visual cues, disable manual resizing, and better handle long or wrapped filter expressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->