### PR TITLE
fix(cost-estimator): when a model type is not there filter throws an error

### DIFF
--- a/src/costEstimator.ts
+++ b/src/costEstimator.ts
@@ -154,9 +154,22 @@ export async function costEstimator(jsonData: DataformCompiledJson, selectedTags
             }
         }
 
-        const filteredTables = jsonData.tables.filter(table => table.target && targetSet.has(createFullTargetName(table.target)));
-        const filteredOperations = jsonData.operations.filter(operation => operation.target && targetSet.has(createFullTargetName(operation.target)));
-        const filteredAssertions = jsonData.assertions.filter(assertion => assertion.target && targetSet.has(createFullTargetName(assertion.target)));
+        const filteredTables = (jsonData?.tables ?? []).filter(
+        ({ target }) =>
+            target && targetSet.has(createFullTargetName(target))
+        );
+
+        const filteredOperations = (jsonData?.operations ?? []).filter(
+        operation =>
+            operation.target &&
+            targetSet.has(createFullTargetName(operation.target))
+        );
+
+        const filteredAssertions = (jsonData?.assertions ?? []).filter(
+        assertion =>
+            assertion.target &&
+            targetSet.has(createFullTargetName(assertion.target))
+        );
 
         let allResults = [];
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to cost estimation logic for enhanced robustness and code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->