### PR TITLE
fix(ci): gate publish jobs on release-PR merge commit subject

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -33,9 +33,9 @@ jobs:
     # matching the canonical commit subject produced by release-please:
     #   chore(main): release <component> <version>
     outputs:
-      npm_released: ${{ contains(github.event.head_commit.message, 'chore(main): release npm-package') }}
-      pypi_released: ${{ contains(github.event.head_commit.message, 'chore(main): release pypi-package') }}
-      dataform_graph_cli_released: ${{ contains(github.event.head_commit.message, 'chore(main): release dataform-graph-cli') }}
+      npm_released: "${{ contains(github.event.head_commit.message, 'chore(main): release npm-package') }}"
+      pypi_released: "${{ contains(github.event.head_commit.message, 'chore(main): release pypi-package') }}"
+      dataform_graph_cli_released: "${{ contains(github.event.head_commit.message, 'chore(main): release dataform-graph-cli') }}"
     steps:
       - uses: googleapis/release-please-action@v4
         id: release

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,10 +27,15 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    # Note: per-package `skip-github-release: true` in release-please-config.json
+    # means release-please-action never emits the `<path>--tag_name` outputs that
+    # would otherwise gate the publish jobs. Instead, detect a release-PR merge by
+    # matching the canonical commit subject produced by release-please:
+    #   chore(main): release <component> <version>
     outputs:
-      npm_released: ${{ steps.release.outputs['packages/npm--tag_name'] }}
-      pypi_released: ${{ steps.release.outputs['packages/pypi--tag_name'] }}
-      dataform_graph_cli_released: ${{ steps.release.outputs['packages/dataform-graph-cli--tag_name'] }}
+      npm_released: ${{ contains(github.event.head_commit.message, 'chore(main): release npm-package') }}
+      pypi_released: ${{ contains(github.event.head_commit.message, 'chore(main): release pypi-package') }}
+      dataform_graph_cli_released: ${{ contains(github.event.head_commit.message, 'chore(main): release dataform-graph-cli') }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
@@ -41,7 +46,7 @@ jobs:
   publish-npm:
     needs: release-please
     if: |
-      needs.release-please.outputs.npm_released != '' ||
+      needs.release-please.outputs.npm_released == 'true' ||
       (github.event_name == 'workflow_dispatch' && inputs.publish_npm)
     runs-on: ubuntu-latest
     permissions:
@@ -72,7 +77,7 @@ jobs:
   publish-pypi:
     needs: release-please
     if: |
-      needs.release-please.outputs.pypi_released != '' ||
+      needs.release-please.outputs.pypi_released == 'true' ||
       (github.event_name == 'workflow_dispatch' && inputs.publish_pypi)
     runs-on: ubuntu-latest
     permissions:
@@ -102,7 +107,7 @@ jobs:
   publish-dataform-graph-cli:
     needs: release-please
     if: |
-      needs.release-please.outputs.dataform_graph_cli_released != '' ||
+      needs.release-please.outputs.dataform_graph_cli_released == 'true' ||
       (github.event_name == 'workflow_dispatch' && inputs.publish_dataform_graph_cli)
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

The publish jobs in `release-please.yml` have been silently skipped on every release-PR merge — most recently for `npm-package@1.2.0` (#328) and `pypi-package@1.2.0` (#327), neither of which was actually published. Only manual `workflow_dispatch` runs with `publish_*: true` ever publish anything.

**Root cause:** [`release-please-config.json`](../blob/main/release-please-config.json) sets `\"skip-github-release\": true` on every package. With that flag, `release-please-action` logs `✔ Release skipped from strategy config` for each path and **does not emit** the `<path>--tag_name` outputs. The publish-job gates rely on those outputs:

```yaml
npm_released: \${{ steps.release.outputs['packages/npm--tag_name'] }}
# ...
if: needs.release-please.outputs.npm_released != ''
```

→ `npm_released` is always empty → `!= ''` is always false → job skipped.

**Fix:** detect a release-PR merge by matching the canonical commit subject release-please produces (`chore(main): release <component> <version>`). The `workflow_dispatch` force-publish fallback (`inputs.publish_*`) is unchanged.

This preserves the existing `skip-github-release: true` choice in the config (no GitHub Releases get created for the sub-packages).

## Test plan

- [ ] Merge this PR
- [ ] After the next release PR is merged to main (e.g. a future `chore(main): release npm-package <version>`), confirm the matching publish job runs (not skipped)
- [ ] Confirm the `workflow_dispatch` path still works by triggering Run workflow with `publish_npm: true` / `publish_pypi: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This release contains internal infrastructure improvements with no user-facing changes. The CI/CD release detection mechanism has been updated to ensure consistent and reliable package publishing processes.

* **Chores**
  * Updated internal release workflow configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ashish10alex/vscode-dataform-tools/pull/330)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->