### PR TITLE
fix(settings): if there is a regex check for a config option, user is trapped in it  once start editing it

### DIFF
--- a/package.json
+++ b/package.json
@@ -312,16 +312,16 @@
                     ]
                 },
                 "vscode-dataform-tools.sqlfluffConfigPath": {
-                    "type": "string",
+                    "type": ["string", "null"],
                     "default": ".vscode-dataform-tools/.sqlfluff",
                     "description": "Path to sqlfluff config file. Please make sure your .sqlfluff is compatible with .sqlx files",
-                    "pattern": ".*\\/\\.sqlfluff$"
+                    "pattern": "^$|.*\\/\\.sqlfluff$"
                 },
                 "vscode-dataform-tools.sqlfluffExecutablePath": {
-                    "type": "string",
+                    "type": ["string", "null"],
                     "default": "sqlfluff",
                     "description": "Path to sqlfluff executable",
-                    "pattern": "^.*sqlfluff(?:\\.exe)?$"
+                    "pattern": "^$|^.*sqlfluff(?:\\.exe)?$"
                 },
                 "vscode-dataform-tools.sourceAutoCompletionPreference": {
                     "type": "string",
@@ -343,16 +343,16 @@
                     "markdownDescription": "Dataform installation scope to use. Default to `global` which uses the dataform cli installed in global scope when running `dataform install -g @dataform/cli`. Selecting `local` scope would mean dataform cli installation in your workspace folder in `./node_modules/.bin/dataform` will be used. This is created when `npm install @dataform/cli` is ran from the root of the workspace folder."
                 },
                 "vscode-dataform-tools.dataformExecutablePath": {
-                    "type": "string",
+                    "type": ["string", "null"],
                     "default": null,
                     "markdownDescription": "**Override path to dataform executable**\n\n⚠️ **Only use this if the extension cannot find dataform automatically**\n\nThe extension automatically searches:\n- System PATH\n- Common tool managers (mise, asdf, nvm, etc.)\n- Standard installation locations\n\nUse this setting for:\n- **Specific versions** for testing: `/path/to/dataform-v3.0.25`\n- **Company-approved versions**: `/opt/company-tools/dataform`\n- **Non-standard locations**: Custom installation paths\n\n**Example**: `/usr/local/bin/dataform` or `${HOME}/.local/share/mise/installs/npm-dataform-cli/3.0.26/bin/dataform`",
-                    "pattern": "^.*dataform(?:\\.cmd|\\.exe)?$"
+                    "pattern": "^$|^.*dataform(?:\\.cmd|\\.exe)?$"
                 },
                 "vscode-dataform-tools.gcloudExecutablePath": {
-                    "type": "string",
+                    "type": ["string", "null"],
                     "default": null,
                     "markdownDescription": "**Override path to gcloud executable**\n\n⚠️ **Only use this if the extension cannot find gcloud automatically**\n\nThe extension automatically searches:\n- System PATH\n- Common tool managers (mise, asdf, etc.)\n- Standard gcloud installation locations\n\nUse this setting for:\n- **Specific versions** for testing: `/path/to/gcloud-v530.0.0`\n- **Company-approved versions**: `/opt/company-tools/gcloud`\n- **Non-standard locations**: Custom installation paths\n\n**Example**: `/usr/local/bin/gcloud` or `${HOME}/google-cloud-sdk/bin/gcloud`",
-                    "pattern": "^.*gcloud(?:\\.cmd|\\.exe)?$"
+                    "pattern": "^$|^.*gcloud(?:\\.cmd|\\.exe)?$"
                 },
                 "vscode-dataform-tools.compileAndDryRunBeforeFormatting": {
                     "type": "boolean",
@@ -382,10 +382,10 @@
                     "markdownDescription": "Enable debug logging to help troubleshoot issues. Logs will appear in the 'Dataform Tools' output channel."
                 },
                 "vscode-dataform-tools.gcpProjectId": {
-                    "type": "string",
+                    "type": ["string", "null"],
                     "default": null,
                     "markdownDescription": "GCP project ID to use for BigQuery queries. When not provided, the project ID will be inferred from your enviroment typically same as `gcloud config list project`",
-                    "pattern": "^[a-z0-9-]+$"
+                    "pattern": "^$|^[a-z0-9-]+$"
                 },
                 "vscode-dataform-tools.gcpLocation": {
                     "type": "string",

--- a/package.json
+++ b/package.json
@@ -312,13 +312,13 @@
                     ]
                 },
                 "vscode-dataform-tools.sqlfluffConfigPath": {
-                    "type": ["string", "null"],
+                    "type": "string",
                     "default": ".vscode-dataform-tools/.sqlfluff",
                     "description": "Path to sqlfluff config file. Please make sure your .sqlfluff is compatible with .sqlx files",
                     "pattern": "^$|.*\\/\\.sqlfluff$"
                 },
                 "vscode-dataform-tools.sqlfluffExecutablePath": {
-                    "type": ["string", "null"],
+                    "type": "string",
                     "default": "sqlfluff",
                     "description": "Path to sqlfluff executable",
                     "pattern": "^$|^.*sqlfluff(?:\\.exe)?$"
@@ -343,13 +343,13 @@
                     "markdownDescription": "Dataform installation scope to use. Default to `global` which uses the dataform cli installed in global scope when running `dataform install -g @dataform/cli`. Selecting `local` scope would mean dataform cli installation in your workspace folder in `./node_modules/.bin/dataform` will be used. This is created when `npm install @dataform/cli` is ran from the root of the workspace folder."
                 },
                 "vscode-dataform-tools.dataformExecutablePath": {
-                    "type": ["string", "null"],
+                    "type": "string",
                     "default": null,
                     "markdownDescription": "**Override path to dataform executable**\n\n⚠️ **Only use this if the extension cannot find dataform automatically**\n\nThe extension automatically searches:\n- System PATH\n- Common tool managers (mise, asdf, nvm, etc.)\n- Standard installation locations\n\nUse this setting for:\n- **Specific versions** for testing: `/path/to/dataform-v3.0.25`\n- **Company-approved versions**: `/opt/company-tools/dataform`\n- **Non-standard locations**: Custom installation paths\n\n**Example**: `/usr/local/bin/dataform` or `${HOME}/.local/share/mise/installs/npm-dataform-cli/3.0.26/bin/dataform`",
                     "pattern": "^$|^.*dataform(?:\\.cmd|\\.exe)?$"
                 },
                 "vscode-dataform-tools.gcloudExecutablePath": {
-                    "type": ["string", "null"],
+                    "type": "string",
                     "default": null,
                     "markdownDescription": "**Override path to gcloud executable**\n\n⚠️ **Only use this if the extension cannot find gcloud automatically**\n\nThe extension automatically searches:\n- System PATH\n- Common tool managers (mise, asdf, etc.)\n- Standard gcloud installation locations\n\nUse this setting for:\n- **Specific versions** for testing: `/path/to/gcloud-v530.0.0`\n- **Company-approved versions**: `/opt/company-tools/gcloud`\n- **Non-standard locations**: Custom installation paths\n\n**Example**: `/usr/local/bin/gcloud` or `${HOME}/google-cloud-sdk/bin/gcloud`",
                     "pattern": "^$|^.*gcloud(?:\\.cmd|\\.exe)?$"
@@ -382,7 +382,7 @@
                     "markdownDescription": "Enable debug logging to help troubleshoot issues. Logs will appear in the 'Dataform Tools' output channel."
                 },
                 "vscode-dataform-tools.gcpProjectId": {
-                    "type": ["string", "null"],
+                    "type": "string",
                     "default": null,
                     "markdownDescription": "GCP project ID to use for BigQuery queries. When not provided, the project ID will be inferred from your enviroment typically same as `gcloud config list project`",
                     "pattern": "^$|^[a-z0-9-]+$"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated configuration validation to allow empty values for optional tool paths and project ID settings, enabling users to omit settings when specific tools or integrations are not required.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ashish10alex/vscode-dataform-tools/pull/335?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->