### PR TITLE
fix: write compilerOptions back to its existing settings scope

### DIFF
--- a/src/views/register-preview-compiled-panel.ts
+++ b/src/views/register-preview-compiled-panel.ts
@@ -309,10 +309,22 @@ export class CompiledQueryPanel {
                 await selectWorkspaceFolder();
                 vscode.commands.executeCommand("vscode-dataform-tools.showCompiledQueryInWebView");
                 return;
-              case 'updateCompilerOptions':
+              case 'updateCompilerOptions': {
                 const compilerOptions = message.value;
-                vscode.workspace.getConfiguration('vscode-dataform-tools').update('compilerOptions', compilerOptions);
+                const config = vscode.workspace.getConfiguration('vscode-dataform-tools');
+                // Respect where the user has already configured `compilerOptions`.
+                // VS Code's `update()` default writes to Workspace settings, which
+                // leaks team-shared `.vscode/settings.json` when the user
+                // configured the value at the User level. Inspect existing scope
+                // and write back to the same place; fall back to Workspace for
+                // first-time use to preserve previous behavior.
+                const inspect = config.inspect('compilerOptions');
+                const target = inspect?.workspaceValue === undefined && inspect?.globalValue !== undefined
+                  ? vscode.ConfigurationTarget.Global
+                  : vscode.ConfigurationTarget.Workspace;
+                config.update('compilerOptions', compilerOptions, target);
                 return;
+              }
               case 'dependencyGraph':
                 await vscode.commands.executeCommand("vscode-dataform-tools.dependencyGraphPanel");
                 return;


### PR DESCRIPTION
## Problem

When a user adjusts compiler options via the compiled-preview panel (e.g. selecting `--vars=environment=production`), the plugin writes the new value to **Workspace** settings (`.vscode/settings.json`) — regardless of where the user originally configured it.

This is painful in teams that:
- Keep a shared, version-controlled `.vscode/settings.json` for things like formatter / linter config.
- Want compiler options (often per-developer or per-environment) configured at the **User** level, not Workspace.

A developer who sets `vscode-dataform-tools.compilerOptions` in their User settings still sees the value reappear in the repo's `.vscode/settings.json` every time they interact with the panel — VS Code's `WorkspaceConfiguration.update()` defaults to writing at Workspace scope when no target is provided ([API docs](https://code.visualstudio.com/api/references/vscode-api#WorkspaceConfiguration)). Because Workspace settings then override User settings on reads, the User-level configuration is effectively shadowed by the freshly-written Workspace value, so re-setting the value at the User level appears to "not work."

## Root cause

In `src/views/register-preview-compiled-panel.ts`:

```ts
case 'updateCompilerOptions':
  const compilerOptions = message.value;
  vscode.workspace.getConfiguration('vscode-dataform-tools').update('compilerOptions', compilerOptions);
  return;
```

`.update()` is called without an explicit `ConfigurationTarget`, so VS Code falls back to Workspace.

## Fix

Inspect the setting's existing scope via `config.inspect()` and write back to the same scope:

- Only the User-level value is set → `ConfigurationTarget.Global`.
- Otherwise (Workspace value set, both set, or neither) → `ConfigurationTarget.Workspace`.

Fully backward-compatible:
- Users who currently have the value in Workspace settings: no change.
- Users who have the value in User settings only: writes correctly go back to User level.
- First-time users (no value set anywhere): default to Workspace, matching previous behavior.

## Test plan

- [ ] With `vscode-dataform-tools.compilerOptions` set **only at User level**, open the compiled-preview panel and adjust options. Confirm the value updates in User settings and the workspace `.vscode/settings.json` is untouched.
- [ ] With the value set **only at Workspace level**, adjust options via the panel. Confirm Workspace settings update (unchanged behavior).
- [ ] With **no prior value anywhere**, adjust options via the panel. Confirm Workspace settings receive the value (unchanged behavior).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how compiler options are configured. The extension now correctly detects the configuration scope (global or workspace) where users have already set their compiler options and updates them in the same location, rather than always applying changes to a default configuration target.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ashish10alex/vscode-dataform-tools/pull/338?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->