### PR TITLE
feat: skip pre_operations in preview data / run query (#339)

### DIFF
--- a/package.json
+++ b/package.json
@@ -402,6 +402,11 @@
                     "default": false,
                     "markdownDescription": "If enabled, pre-operations query will be excluded from the query used for dry run. By default, pre-operations are included. `::WARNING::` any variable used in pre-operations query will not be resolved and will result in an error"
                 },
+                "vscode-dataform-tools.skipPreOpsInPreviewQuery": {
+                    "type": "boolean",
+                    "default": false,
+                    "markdownDescription": "If enabled, the pre-operations (and incremental pre-operations) block is excluded from the query run by `Preview Data` / `Run`. Useful to preview a model's output without executing side effects such as `DELETE`/`MERGE` in `pre_operations`. By default, pre-operations are included."
+                },
                 "vscode-dataform-tools.formatOrdering": {
                     "type": "array",
                     "uniqueItems": true,

--- a/src/previewQueryResults.ts
+++ b/src/previewQueryResults.ts
@@ -11,19 +11,25 @@ export async function runQueryInPanel(queryWtType: QueryWtType, queryResultsView
     }
 }
 
-export function getQueryStringForPreview(fileMetadata: TablesWtFullQuery, isIncremental: boolean): string {
+export function getQueryStringForPreview(fileMetadata: TablesWtFullQuery, isIncremental: boolean, skipPreOps?: boolean): string {
+    if (skipPreOps === undefined) {
+        skipPreOps = vscode.workspace.getConfiguration('vscode-dataform-tools').get('skipPreOpsInPreviewQuery') ?? false;
+    }
+    const preOpsQuery = skipPreOps ? "" : fileMetadata.queryMeta.preOpsQuery;
+    const incrementalPreOpsQuery = skipPreOps ? "" : fileMetadata.queryMeta.incrementalPreOpsQuery;
+
     let query = "";
     if (fileMetadata.queryMeta.type === "assertion") {
         query = fileMetadata.queryMeta.assertionQuery;
     } else if (fileMetadata.queryMeta.type === "table" || fileMetadata.queryMeta.type === "view") {
-        query = fileMetadata.queryMeta.preOpsQuery + fileMetadata.queryMeta.tableQueries.map((t: { query: string }) => t.query).join("\n");
+        query = preOpsQuery + fileMetadata.queryMeta.tableQueries.map((t: { query: string }) => t.query).join("\n");
     } else if (fileMetadata.queryMeta.type === "operations") {
-        query = fileMetadata.queryMeta.preOpsQuery + fileMetadata.queryMeta.operationsQuery;
+        query = preOpsQuery + fileMetadata.queryMeta.operationsQuery;
     } else if (fileMetadata.queryMeta.type === "incremental") {
         if (isIncremental === true){
-            query = fileMetadata.queryMeta.incrementalPreOpsQuery + fileMetadata.queryMeta.incrementalQueries.map((q: { incrementalQuery: string }) => q.incrementalQuery).join("\n");
+            query = incrementalPreOpsQuery + fileMetadata.queryMeta.incrementalQueries.map((q: { incrementalQuery: string }) => q.incrementalQuery).join("\n");
         } else {
-            query = fileMetadata.queryMeta.preOpsQuery + fileMetadata.queryMeta.incrementalQueries.map((q: { nonIncrementalQuery: string }) => q.nonIncrementalQuery).join("\n");
+            query = preOpsQuery + fileMetadata.queryMeta.incrementalQueries.map((q: { nonIncrementalQuery: string }) => q.nonIncrementalQuery).join("\n");
         }
     } else if (fileMetadata.queryMeta.type === "test") {
         query = fileMetadata.queryMeta.testQuery;

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -11,6 +11,7 @@ import { tableQueryOffset, incrementalTableOffset } from '../../constants';
 import { setDiagnostics } from '../../setDiagnostics';
 import { calculateIncrementalSkipPreOpsOffset } from '../../offsetCalculations';
 import { getDocumentSymbols } from '../../documentSymbols';
+import { getQueryStringForPreview } from '../../previewQueryResults';
 
 /*
 WARN: The test would not be able to run if your project path is very long this is a known issue reported in https://github.com/microsoft/vscode-test/issues/232
@@ -859,6 +860,78 @@ suite('handleSemicolonPrePostOps', () => {
 `);
         assert.strictEqual(result.queryMeta.incrementalPreOpsQuery, result.queryMeta.incrementalPreOpsQuery);
         assert.strictEqual(result.queryMeta.postOpsQuery, result.queryMeta.postOpsQuery);
+    });
+
+});
+
+suite("getQueryStringForPreview skipPreOps", () => {
+    const PRE_OPS = "DELETE FROM `proj.ds.tbl` WHERE date = '2024-01-01';";
+    const INC_PRE_OPS = "DELETE FROM `proj.ds.tbl` WHERE date BETWEEN start AND end;";
+    const SELECT = "SELECT date, COUNT(*) AS events FROM `proj.ds.src` GROUP BY date";
+
+    const buildFileMetadata = (type: string) => ({
+        tables: [],
+        queryMeta: {
+            type,
+            preOpsQuery: PRE_OPS,
+            incrementalPreOpsQuery: INC_PRE_OPS,
+            postOpsQuery: "",
+            assertionQuery: "",
+            assertionQueries: [],
+            tableQueries: [{ targetName: "t", query: SELECT, preOpsQuery: PRE_OPS }],
+            incrementalQueries: [{
+                targetName: "t",
+                incrementalQuery: SELECT,
+                nonIncrementalQuery: SELECT,
+                preOpsQuery: PRE_OPS,
+                incrementalPreOpsQuery: INC_PRE_OPS,
+            }],
+            operationQueries: [],
+            operationsQuery: SELECT,
+            testQuery: "",
+            expectedOutputQuery: "",
+            testQueries: [],
+            error: "",
+        }
+    });
+
+    test("table: includes pre-ops when skipPreOps is false", () => {
+        const query = getQueryStringForPreview(buildFileMetadata("table") as any, false, false);
+        assert.ok(query.includes(PRE_OPS), "expected pre-ops to be included");
+        assert.ok(query.includes(SELECT), "expected select to be included");
+    });
+
+    test("table: excludes pre-ops when skipPreOps is true", () => {
+        const query = getQueryStringForPreview(buildFileMetadata("table") as any, false, true);
+        assert.ok(!query.includes(PRE_OPS), "expected pre-ops to be excluded");
+        assert.strictEqual(query, SELECT);
+    });
+
+    test("view: excludes pre-ops when skipPreOps is true", () => {
+        const query = getQueryStringForPreview(buildFileMetadata("view") as any, false, true);
+        assert.strictEqual(query, SELECT);
+    });
+
+    test("operations: excludes pre-ops when skipPreOps is true", () => {
+        const withPreOps = getQueryStringForPreview(buildFileMetadata("operations") as any, false, false);
+        assert.ok(withPreOps.includes(PRE_OPS));
+        const skipped = getQueryStringForPreview(buildFileMetadata("operations") as any, false, true);
+        assert.strictEqual(skipped, SELECT);
+    });
+
+    test("incremental (isIncremental=true): excludes incremental pre-ops when skipPreOps is true", () => {
+        const withPreOps = getQueryStringForPreview(buildFileMetadata("incremental") as any, true, false);
+        assert.ok(withPreOps.includes(INC_PRE_OPS));
+        const skipped = getQueryStringForPreview(buildFileMetadata("incremental") as any, true, true);
+        assert.ok(!skipped.includes(INC_PRE_OPS), "expected incremental pre-ops to be excluded");
+        assert.strictEqual(skipped, SELECT);
+    });
+
+    test("incremental (isIncremental=false): excludes pre-ops when skipPreOps is true", () => {
+        const withPreOps = getQueryStringForPreview(buildFileMetadata("incremental") as any, false, false);
+        assert.ok(withPreOps.includes(PRE_OPS));
+        const skipped = getQueryStringForPreview(buildFileMetadata("incremental") as any, false, true);
+        assert.strictEqual(skipped, SELECT);
     });
 
 });


### PR DESCRIPTION
Closes #339

## Problem
Both the **"Run"** button (lower pane) and **"Preview Data"** (right pane) funnel through `getQueryStringForPreview()`, which always prepended the compiled `pre_operations` SQL. For an incremental model whose `pre_operations` does `DELETE FROM ${self()} ...`, previewing the output would actually **delete rows**. This mirrors the Dataform UI "Run", which previews the `SELECT` without side-effecting pre-ops.

## Changes
- **New setting** `vscode-dataform-tools.skipPreOpsInPreviewQuery` (boolean, default `false`) — independent of the existing `skipPreOpsInDryRun` setting.
- `getQueryStringForPreview()` gains an optional `skipPreOps?` arg; when omitted it reads the new setting. When enabled, `preOpsQuery` / `incrementalPreOpsQuery` are excluded, leaving only the `SELECT`. Both existing call sites pick this up automatically. The `assertion` / `test` branches are unaffected (no pre-ops).
- **6 new unit tests** covering table/view, operations, and incremental (both `isIncremental` modes).

Note: pre-op-declared JS variables (the `js {}` block) are resolved at compile time and already substituted into the compiled SELECT, so dropping the compiled `pre_operations` SQL does not break the preview query.

## Verification
- `npm run compile` ✅
- `npm run lint` ✅
- `npx vscode-test` ✅ — 40 passing (incl. 6 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new configuration setting to skip pre-operations in preview and run queries, preventing unintended side effects from commands such as DELETE or MERGE operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->