### PR TITLE
fix: tags in operation type was not being picked up

### DIFF
--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -4,7 +4,7 @@ globalThis.errorInPreOpsDenyList = false;
 globalThis.compilerOptionsMap = {};
 import path from 'path';
 import * as vscode from 'vscode';
-import { compileDataform, formatBytes, getQueryMetaForCurrentFile, handleSemicolonPrePostOps, buildIndices } from '../../utils';
+import { compileDataform, formatBytes, getQueryMetaForCurrentFile, handleSemicolonPrePostOps, buildIndices, getDataformTags } from '../../utils';
 import { DataformCompiledJson } from '../../types';
 import { getMetadataForSqlxFileBlocks } from '../../sqlxFileParser';
 import { tableQueryOffset, incrementalTableOffset } from '../../constants';
@@ -932,6 +932,40 @@ suite("getQueryStringForPreview skipPreOps", () => {
         assert.ok(withPreOps.includes(PRE_OPS));
         const skipped = getQueryStringForPreview(buildFileMetadata("incremental") as any, false, true);
         assert.strictEqual(skipped, SELECT);
+    });
+
+});
+
+suite('getDataformTags', () => {
+
+    test("tags are collected from tables, assertions, operations and notebooks", async function () {
+        this.timeout(9000);
+        try {
+            let { compiledString, errors } = await compileDataform(workspaceFolder);
+            if (compiledString) {
+                const dataformCompiledJson: DataformCompiledJson = JSON.parse(compiledString);
+                if (dataformCompiledJson) {
+                    let dataformTags = await getDataformTags(dataformCompiledJson);
+
+                    // FOOTY is on multiple tables, so this also asserts that tags are de-duplicated
+                    assert.deepStrictEqual(dataformTags, ["FOOTY", "OPS_TAG", "new_tag", "tag2"]);
+                } else {
+                    throw new Error('Compilation failed');
+                }
+            }
+            if (errors) {
+                throw new Error(JSON.stringify(errors, null, 2));
+            }
+        } catch (error: any) {
+            console.error('Test failed:', error);
+            vscode.window.showErrorMessage(`Test failed: ${error.message}`);
+            throw error;
+        }
+    });
+
+    test("no tags are returned when the compiled json has no actions", async function () {
+        let dataformTags = await getDataformTags({} as DataformCompiledJson);
+        assert.deepStrictEqual(dataformTags, []);
     });
 
 });

--- a/src/test/test-workspace/definitions/0500_OPERATIONS.sqlx
+++ b/src/test/test-workspace/definitions/0500_OPERATIONS.sqlx
@@ -1,6 +1,7 @@
 config {
   type: 'operations',
-  hasOutput: true
+  hasOutput: true,
+  tags: ["OPS_TAG"]
 }
 
 DROP TABLE IF EXISTS

--- a/src/utils/queryMetadata.ts
+++ b/src/utils/queryMetadata.ts
@@ -339,28 +339,19 @@ export async function getQueryMetaForCurrentFile(relativeFilePath: string, compi
 }
 
 export async function getDataformTags(compiledJson: DataformCompiledJson) {
-    let dataformTags: string[] = [];
-    let tables = compiledJson?.tables;
-    if (tables) {
-        tables.forEach((table) => {
-            table?.tags?.forEach((tag) => {
-                if (dataformTags.includes(tag) === false) {
-                    dataformTags.push(tag);
-                }
-            });
+    let dataformTags = new Set<string>();
+    let taggedActions = [
+        ...(compiledJson?.tables ?? []),
+        ...(compiledJson?.assertions ?? []),
+        ...(compiledJson?.operations ?? []),
+        ...(compiledJson?.notebooks ?? []),
+    ];
+    taggedActions.forEach((action) => {
+        action?.tags?.forEach((tag) => {
+            dataformTags.add(tag);
         });
-    };
-    let assertions = compiledJson?.assertions;
-    if (assertions) {
-        assertions.forEach((assertion) => {
-            assertion?.tags?.forEach((tag) => {
-                if (dataformTags.includes(tag) === false) {
-                    dataformTags.push(tag);
-                }
-            });
-        });
-    }
-    return dataformTags.sort();
+    });
+    return Array.from(dataformTags).sort();
 }
 
 export async function getDependenciesAutoCompletionItems(compiledJson: DataformCompiledJson) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tag discovery now includes tables, assertions, operations and notebooks.
  * Duplicate tags are automatically removed and results are returned in alphabetical order.
  * Operations tags are now recognised alongside existing action tags.

* **Bug Fixes**
  * Improved tag collection when projects contain multiple action types.
  * Correctly handles projects with no actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->