### PR TITLE
fix: webview table filter no longer steals focus from the editor

### DIFF
--- a/webviews/components/ui/data-table.tsx
+++ b/webviews/components/ui/data-table.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
   ColumnDef,
   flexRender,
@@ -10,6 +10,7 @@ import {
   useReactTable,
   SortingState,
   ColumnFiltersState,
+  Column,
 } from '@tanstack/react-table';
 import { ArrowUpDown, ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight } from 'lucide-react';
 
@@ -22,6 +23,36 @@ interface DataTableProps<TData, TValue> {
   initialSorting?: SortingState
   /** Render with pagination controls + page-size dropdown. Defaults to true. */
   paginated?: boolean
+}
+
+function ColumnFilterInput({ column, shouldAutoFocus }: { column: Column<any, unknown>; shouldAutoFocus: boolean }) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    // Only take focus when the webview already has it. The panel is opened with
+    // preserveFocus, so grabbing focus on mount would pull the cursor out of the
+    // editor whenever the active file changes.
+    if (shouldAutoFocus && document.hasFocus()) {
+      inputRef.current?.focus();
+    }
+  }, []);
+
+  return (
+    <input
+      ref={inputRef}
+      type="text"
+      value={(column.getFilterValue() ?? '') as string}
+      onChange={(e) => column.setFilterValue(e.target.value)}
+      onKeyDown={(e) => {
+        if (e.key === 'Escape') {
+          e.currentTarget.blur();
+        }
+      }}
+      placeholder={`Filter...`}
+      className="w-full px-2 py-1 text-xs border rounded bg-[var(--vscode-input-background)] border-[var(--vscode-input-border)] focus:outline-none focus:ring-1 focus:ring-[var(--vscode-focusBorder)] text-[var(--vscode-input-foreground)] placeholder:text-[var(--vscode-input-placeholderForeground)]"
+      onClick={(e) => e.stopPropagation()} // Prevent sorting when clicking input
+    />
+  );
 }
 
 export function DataTable<TData, TValue>({
@@ -101,19 +132,9 @@ export function DataTable<TData, TValue>({
                             {/* Column Filter Input */}
                             {header.column.getCanFilter() ? (
                                 <div>
-                                    <input
-                                        type="text"
-                                        autoFocus={header.column.id === autoFocusColumnId}
-                                        value={(header.column.getFilterValue() ?? '') as string}
-                                        onChange={(e) => header.column.setFilterValue(e.target.value)}
-                                        onKeyDown={(e) => {
-                                            if (e.key === 'Escape') {
-                                                e.currentTarget.blur();
-                                            }
-                                        }}
-                                        placeholder={`Filter...`}
-                                        className="w-full px-2 py-1 text-xs border rounded bg-[var(--vscode-input-background)] border-[var(--vscode-input-border)] focus:outline-none focus:ring-1 focus:ring-[var(--vscode-focusBorder)] text-[var(--vscode-input-foreground)] placeholder:text-[var(--vscode-input-placeholderForeground)]"
-                                        onClick={(e) => e.stopPropagation()} // Prevent sorting when clicking input
+                                    <ColumnFilterInput
+                                        column={header.column}
+                                        shouldAutoFocus={header.column.id === autoFocusColumnId}
                                     />
                                 </div>
                             ) : null}


### PR DESCRIPTION
## Problem

Switching the active editor from a `.sqlx` file to a `.js` file (e.g. `docs.js`) moved the cursor out of the editor and into the compiled preview webview, landing in the table's "Filter..." box.

## Cause

`webviews/components/ui/data-table.tsx` set React's `autoFocus` on the column filter input. When the active editor changes to a `.js` file that declares sources, the compiled preview panel re-renders and takes the `DeclarationsView` branch (`webviews/preview_compiled/App.tsx:149`), which mounts a `DataTable` with `autoFocusColumnId="dataset"`. That fresh mount fired `autoFocus` on an already-visible panel, pulling focus into the webview.

This silently overrode the extension side, which already creates the panel with `preserveFocus: true` (`src/views/register-preview-compiled-panel.ts:190`).

## Fix

Extract the filter input into a `ColumnFilterInput` component that focuses on mount only when `document.hasFocus()` — i.e. only when the webview already had focus.

- File switch while typing in the editor: webview isn't focused, so nothing is stolen.
- Schema tab, dependency-graph schema modal, latest run banner: you're already inside the webview when the table mounts, so these keep autofocusing as before.

The tag-picker `autoFocus` in `CompiledQueryTab.tsx:610` is inside a popover opened by hand and is left unchanged.

## Verification

- `npm run check-types` passes
- `npm run build:webviews` succeeds
- Behaviour confirmed manually by @ashish10alex

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table header filter focus behaviour so inputs only receive focus when the webview is already active.
  * Prevented filter inputs from unexpectedly stealing focus when opening or interacting with the webview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->