### PR TITLE
feat: add executionTimeout setting for dataform run

### DIFF
--- a/package.json
+++ b/package.json
@@ -297,6 +297,12 @@
                     "pattern": "^(\\d+[sm])+$",
                     "markdownDescription": "Duration to allow project compilation to complete. Use format like '5m', '60s' etc. Passed to `dataform compile --json --timeout=<value>`"
                 },
+                "vscode-dataform-tools.executionTimeout": {
+                    "type": "string",
+                    "default": "",
+                    "pattern": "^$|^(\\d+[smh])+$",
+                    "markdownDescription": "Wall-clock deadline for an entire `dataform run` (compilation plus all actions). When it fires, in-flight actions are cancelled and pending actions are skipped. Use format like '10m', '2h' etc. Passed to `dataform run --execution-timeout=<value>`. Leave empty to disable, which is the Dataform CLI default.\n\nNote: `#vscode-dataform-tools.defaultDataformCompileTime#` only bounds the compilation step, not the run as a whole. Requires Dataform CLI 3.0.66 or later."
+                },
                 "vscode-dataform-tools.gitRepoName": {
                     "type": "string",
                     "default": "",

--- a/src/runTag.ts
+++ b/src/runTag.ts
@@ -1,4 +1,4 @@
-import { getCachedDataformRepositoryLocation, getDataformCliCmdBasedOnScope, getDataformCompilationTimeoutFromConfig, getDataformCompilerOptions, getWorkspaceFolder, runCommandInTerminal, showLoadingProgress } from "./utils";
+import { getCachedDataformRepositoryLocation, getDataformCliCmdBasedOnScope, getDataformCompilationTimeoutFromConfig, getDataformCompilerOptions, getDataformExecutionTimeoutFromConfig, getWorkspaceFolder, runCommandInTerminal, showLoadingProgress } from "./utils";
 import * as vscode from 'vscode';
 import { DataformTools } from "@ashishalex/dataform-tools";
 import { sendWorkflowInvocationNotification, syncAndrunDataformRemotely} from "./dataformApiUtils";
@@ -25,6 +25,10 @@ export function getRunTagsWtOptsCommand(workspaceFolder: string, tags: string[] 
     let dataformCompilerOptions = getDataformCompilerOptions();
     const customDataformCliPath = getDataformCliCmdBasedOnScope(workspaceFolder);
     let cmd = `${customDataformCliPath} run "${workspaceFolder}" ${dataformCompilerOptions} --timeout=${dataformCompilationTimeoutVal}`;
+    const dataformExecutionTimeoutVal = getDataformExecutionTimeoutFromConfig();
+    if (dataformExecutionTimeoutVal) {
+        cmd += ` --execution-timeout=${dataformExecutionTimeoutVal}`;
+    }
     if (typeof tags === "object") {
         for (let tag of tags) {
             cmd += ` --tags=${tag}`;

--- a/src/utils/dataformCompiler.ts
+++ b/src/utils/dataformCompiler.ts
@@ -90,6 +90,19 @@ export function getDataformCompilationTimeoutFromConfig() {
     return "5m";
 }
 
+/**
+ * Wall-clock deadline for an entire `dataform run`, passed as `--execution-timeout`.
+ * Unset by default, matching the Dataform CLI, where the deadline is off unless asked for.
+ * Note that `--timeout` only bounds the compilation step of a run.
+ */
+export function getDataformExecutionTimeoutFromConfig(): string | undefined {
+    let dataformExecutionTimeoutVal: string | undefined = vscode.workspace.getConfiguration('vscode-dataform-tools').get('executionTimeout');
+    if (dataformExecutionTimeoutVal) {
+        return dataformExecutionTimeoutVal;
+    }
+    return undefined;
+}
+
 export function getDataformCompilerOptions() {
     let dataformCompilerOptions: string | undefined = vscode.workspace.getConfiguration('vscode-dataform-tools').get('compilerOptions');
     if (dataformCompilerOptions) {

--- a/src/utils/dataformHelpers.ts
+++ b/src/utils/dataformHelpers.ts
@@ -8,7 +8,7 @@ import { DataformTools } from "@ashishalex/dataform-tools";
 import { sendWorkflowInvocationNotification, syncAndrunDataformRemotely } from "../dataformApiUtils";
 import { CurrentFileMetadata, Target, Table, Operation, Assertion, Declarations, ExecutionMode } from '../types';
 import { getWorkspaceFolder, selectWorkspaceFolder, getFileNameFromDocument, getAllFilesWtAnExtension } from './workspaceUtils';
-import { runCompilation, getOrCompileDataformJson, getDataformCompilationTimeoutFromConfig, getDataformCompilerOptions, getDataformCliCmdBasedOnScope } from './dataformCompiler';
+import { runCompilation, getOrCompileDataformJson, getDataformCompilationTimeoutFromConfig, getDataformCompilerOptions, getDataformExecutionTimeoutFromConfig, getDataformCliCmdBasedOnScope } from './dataformCompiler';
 import { getQueryMetaForCurrentFile } from './queryMetadata';
 import { getCachedDataformRepositoryLocation } from './gcpUtils';
 import { showLoadingProgress, runCommandInTerminal } from './vscodeUi';
@@ -399,6 +399,10 @@ export function getDataformActionCmdFromActionList(actionsList: string[], worksp
     let dataformCompilerOptions = getDataformCompilerOptions();
     const customDataformCliPath = getDataformCliCmdBasedOnScope(workspaceFolder);
     let cmd = `${customDataformCliPath} run "${workspaceFolder}" ${dataformCompilerOptions} --timeout=${dataformCompilationTimeoutVal}`;
+    const dataformExecutionTimeoutVal = getDataformExecutionTimeoutFromConfig();
+    if (dataformExecutionTimeoutVal) {
+        cmd += ` --execution-timeout=${dataformExecutionTimeoutVal}`;
+    }
     for (let i = 0; i < actionsList.length; i++) {
         let fullTableName = actionsList[i];
         if (i === 0) {


### PR DESCRIPTION
## Context

Dataform CLI **3.0.66** split the run deadline into two flags:

| flag | scope |
|---|---|
| `--timeout` | project compilation only |
| `--execution-timeout` | the entire run (compile + all actions) |

The extension only ever passed `--timeout` to `dataform run`, so there was no way to bound a long-running invocation. Since 3.0.66 the CLI also prints a note on every run when `--timeout` is passed without `--execution-timeout`:

> Note: --timeout only bounds project compilation. For a whole-run wall-clock deadline, use --execution-timeout.

## Change

Adds an opt-in `vscode-dataform-tools.executionTimeout` setting mapped to `--execution-timeout`, applied to both run command builders:

- `getRunTagsWtOptsCommand` (`src/runTag.ts`) — tag runs
- `getDataformActionCmdFromActionList` (`src/utils/dataformHelpers.ts`) — action list runs

Backed by `getDataformExecutionTimeoutFromConfig()` in `src/utils/dataformCompiler.ts`, alongside the existing `getDataformCompilationTimeoutFromConfig()`.

## Notes

- **Unset by default**, matching the CLI, where the deadline is off unless asked for. No behaviour change for anyone who does not set it.
- The existing `defaultDataformCompileTime` → `--timeout` mapping is unchanged and remains correct: it *is* a compilation timeout.
- Setting a value also silences the CLI note above.
- Requires CLI 3.0.66+ to take effect. Older CLIs reject the unknown flag, which is why this is opt-in rather than defaulted.

## Verification

- `npm run check-types` and `eslint src --ext ts` pass clean
- `--execution-timeout` confirmed present in `dataform run --help` on CLI 3.0.69
- Setting `pattern` accepts `10m` / `2h` / empty, rejects junk

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional execution-timeout setting for Dataform runs.
  - Users can configure a wall-clock limit using seconds, minutes, or hours.
  - When the limit is reached, active actions are cancelled and pending actions are skipped.
  - The setting is disabled by default and requires Dataform CLI 3.0.66 or later.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->