### PR TITLE
feat: support PropertyGraph actions in dependency graph and tags

### DIFF
--- a/src/shared/buildDependencyGraph.ts
+++ b/src/shared/buildDependencyGraph.ts
@@ -1,4 +1,4 @@
-import { Assertion, DataformCompiledJson, Declarations, DependancyModelMetadata, Operation, Table } from "../types";
+import { Assertion, DataformCompiledJson, Declarations, DependancyModelMetadata, Operation, PropertyGraph, Table } from "../types";
 
 export interface GraphEdge {
     id: string;
@@ -47,8 +47,8 @@ const datasetColors = [
     "#38BDF8"  // Light Sky Blue
 ];
 
-type StructType = "tables" | "assertions" | "operations" | "declarations";
-type AnyStruct = Table | Operation | Assertion | Declarations;
+type StructType = "tables" | "assertions" | "operations" | "declarations" | "propertyGraphs";
+type AnyStruct = Table | Operation | Assertion | Declarations | PropertyGraph;
 
 interface PopulateState {
     nodes: DependancyModelMetadata[];
@@ -154,6 +154,7 @@ export function buildDependencyGraph(
     if (compiled.assertions) { populate("assertions", compiled.assertions, state, focusIdentifier); }
     if (compiled.operations) { populate("operations", compiled.operations, state, focusIdentifier); }
     if (compiled.declarations) { populate("declarations", compiled.declarations, state, focusIdentifier); }
+    if (compiled.propertyGraphs) { populate("propertyGraphs", compiled.propertyGraphs, state, focusIdentifier); }
 
     return {
         nodes: state.nodes,

--- a/src/types.ts
+++ b/src/types.ts
@@ -96,6 +96,22 @@ export interface Declarations {
     fileName: string;
 }
 
+/**
+ * PropertyGraph action, added to the compiled graph in @dataform/core 3.0.65.
+ * Has no `type` field and no queries: it declares entities and relationships
+ * over existing tables rather than producing a query of its own.
+ */
+export interface PropertyGraph {
+    target: Target;
+    canonicalTarget: Target;
+    dependencyTargets: Target[];
+    fileName: string;
+    tags: string[];
+    description?: string;
+    graphBody?: string;
+    disabled?: boolean;
+}
+
 export interface ProjectConfig {
     warehouse: string;
     defaultSchema: string;
@@ -164,6 +180,8 @@ export interface DataformCompiledJson {
     graphErrors: GraphErrors;
     notebooks: Notebook[];
     tests: Test[];
+    /** Requires @dataform/core 3.0.65 or later, so absent on older compiled output. */
+    propertyGraphs?: PropertyGraph[];
     dataformCoreVersion?: string;
 }
 

--- a/src/utils/queryMetadata.ts
+++ b/src/utils/queryMetadata.ts
@@ -345,6 +345,7 @@ export async function getDataformTags(compiledJson: DataformCompiledJson) {
         ...(compiledJson?.assertions ?? []),
         ...(compiledJson?.operations ?? []),
         ...(compiledJson?.notebooks ?? []),
+        ...(compiledJson?.propertyGraphs ?? []),
     ];
     taggedActions.forEach((action) => {
         action?.tags?.forEach((tag) => {

--- a/webviews/dependancy_graph/TableNode.tsx
+++ b/webviews/dependancy_graph/TableNode.tsx
@@ -17,7 +17,7 @@ interface NodeData {
   tags: string[];
   fileName: string;
   datasetColor: string;
-  type: 'view' | 'table' | 'operation' | 'operations' | 'source' | 'assertions';
+  type: 'view' | 'table' | 'operation' | 'operations' | 'source' | 'assertions' | 'propertyGraphs';
   onNodeClick: (nodeId: string) => void;
   isExternalSource: boolean;
   fullTableName: string;


### PR DESCRIPTION
## Context

`@dataform/core` **3.0.65** added `propertyGraphs` as a new top-level collection on the compiled graph. **3.0.68** gave those actions `ref()`-based DAG dependencies, and **3.0.69** added tag support.

The full `CompiledGraph` proto in 3.0.69 is:

```
tables, operations, assertions, declarations, tests, notebooks,
dataPreparations, propertyGraphs, graphErrors, dataformCoreVersion, targets, jitData
```

`DataformCompiledJson` had no `propertyGraphs` field, so PropertyGraph actions were dropped entirely:

- missing as nodes in the dependency graph
- missing as edge sources for models that `ref()` them
- their tags never reached the tag picker

## Change

- **`src/types.ts`** — new `PropertyGraph` interface, and optional `propertyGraphs` on `DataformCompiledJson`
- **`src/shared/buildDependencyGraph.ts`** — `propertyGraphs` added to `StructType` / `AnyStruct` and populated
- **`src/utils/queryMetadata.ts`** — `getDataformTags` now reads PropertyGraph tags
- **`webviews/dependancy_graph/TableNode.tsx`** — node type union widened

`PropertyGraph` has no `type` field (it declares entities and relationships rather than producing a query), so `populate` falls back to the collection name, matching how `declarations` already behaves.

The field is **optional** — older `@dataform/core` versions do not emit it, and `buildDependencyGraph` already guards each collection.

## Deliberately out of scope

- `costEstimator` — PropertyGraphs have no query to dry-run, so excluding them is correct
- `dependency-inspector-panel` / `compiledJsonIndex` — worth a separate look, kept out to keep this reviewable
- `dataPreparations` — also missing from the type, but a pre-existing gap unrelated to these releases

## Verification

- `npm run check-types`, `eslint src --ext ts`, and `npm run build:webviews` all pass clean
- Ran `buildDependencyGraph` against a fixture with a PropertyGraph that `ref()`s a table:

```
nodes: orders[table], shop_graph[propertyGraphs]
edges: 0->1 tags=["graph"]
```

The node is created and the dependency edge from `orders` resolves.

## Note for whoever merges

This touches `getDataformTags`, as does #350 (declaration tags). Whichever lands second needs a one-line rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
