### PR TITLE
fix: include declaration tags in the tag picker

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -90,7 +90,7 @@ export interface Target {
 
 export interface Declarations {
     target: Target;
-    tags: string[]; // WARN: This is not a valid object for Declarations adding this to avoid type errors when using abstractions
+    tags: string[]; // Declarations gained tag support in @dataform/core 3.0.52, so this is absent on older compiled output
     canonicalTarget: Target;
     dependencyTargets: Target[]; // WARN: This is not a valid object for Declarations adding this to avoid type errors when using abstractions
     fileName: string;

--- a/src/utils/queryMetadata.ts
+++ b/src/utils/queryMetadata.ts
@@ -346,6 +346,7 @@ export async function getDataformTags(compiledJson: DataformCompiledJson) {
         ...(compiledJson?.operations ?? []),
         ...(compiledJson?.notebooks ?? []),
         ...(compiledJson?.propertyGraphs ?? []),
+        ...(compiledJson?.declarations ?? []),
     ];
     taggedActions.forEach((action) => {
         action?.tags?.forEach((tag) => {


### PR DESCRIPTION
## Context

`@dataform/core` **3.0.52** introduced tags on declarations. Confirmed against the 3.0.69 proto:

```
IDeclaration: target, canonicalTarget, actionDescriptor, fileName, tags
```

`getDataformTags` (`src/utils/queryMetadata.ts:341`) only collected from tables, assertions, operations and notebooks. Tags declared on sources were silently dropped from the tag quick-pick and from the tag-based run commands that read it.

## Change

- Adds `declarations` to the `taggedActions` list in `getDataformTags`
- Corrects the stale `WARN` comment on `Declarations.tags` in `src/types.ts`

That comment claimed tags were "not a valid object for Declarations" and only present to avoid type errors. That was true when written, but as of 3.0.52 the field is real. The matching comment on `dependencyTargets` is **left alone** — declarations still have no such field in the 3.0.69 proto, so it remains accurate.

The existing `action?.tags?.forEach` optional chaining keeps this safe against older compiled output where declarations carry no tags.

## Verification

- `npm run check-types` and `eslint src --ext ts` pass clean

## Note for whoever merges

This touches `getDataformTags`, as does #349 (PropertyGraph support). Whichever lands second needs a one-line rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)