### PR TITLE
feat: render property graphs in the compiled query webview

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -104,6 +104,17 @@ export async function activate(context: vscode.ExtensionContext) {
         })
     );
 
+    // Runs a query the extension generated rather than one taken from the active file,
+    // e.g. the starter GQL query built from a property graph.
+    context.subscriptions.push(
+        vscode.commands.registerCommand('vscode-dataform-tools.runGeneratedQuery', async (query: string, type: string) => {
+            if (!query) {
+                return;
+            }
+            await runQueryInPanel({ query: query, type: type || "table" }, queryResultsViewProvider);
+        })
+    );
+
     context.subscriptions.push(vscode.commands.registerCommand('vscode-dataform-tools.dependencyGraphPanel', async () => {
         createDependencyGraphPanel(context, vscode.ViewColumn.One);
     }));

--- a/src/runCurrentFile.ts
+++ b/src/runCurrentFile.ts
@@ -4,6 +4,7 @@ import { DataformTools } from "@ashishalex/dataform-tools";
 import { sendWorkflowInvocationNotification, syncAndrunDataformRemotely } from "./dataformApiUtils";
 import { ExecutionMode } from './types';
 import { GitService } from './gitClient';
+import { getPropertyGraphsForFile } from './shared/propertyGraph';
 
 export async function runCurrentFile(context: vscode.ExtensionContext, includDependencies: boolean, includeDependents: boolean, fullRefresh: boolean, executionMode:ExecutionMode): Promise<{ workflowInvocationUrlGCP: string|undefined; errorWorkflowInvocation: string|undefined; } | undefined> {
 
@@ -47,10 +48,24 @@ export async function runCurrentFile(context: vscode.ExtensionContext, includDep
         return;
     }
 
+    // PropertyGraph actions produce no queries, so they are absent from `tables` and have to be
+    // picked up from the compiled output directly for the file to be runnable at all.
+    const propertyGraphs = getPropertyGraphsForFile(relativeFilePath, CACHED_COMPILED_DATAFORM_JSON)
+        .filter((graph) => !graph.disabled);
+
     if (executionMode === "cli") {
         let actionsList: string[] = currFileMetadata.tables
             .filter((table: any) => table.type !== 'test')
             .map(table => `${table.target.database}.${table.target.schema}.${table.target.name}`);
+
+        propertyGraphs.forEach((graph) => {
+            actionsList.push(`${graph.target.database}.${graph.target.schema}.${graph.target.name}`);
+        });
+
+        if (actionsList.length === 0) {
+            vscode.window.showErrorMessage(`No runnable Dataform actions found in ${relativeFilePath}`);
+            return;
+        }
 
         let dataformActionCmd = "";
 
@@ -74,6 +89,15 @@ export async function runCurrentFile(context: vscode.ExtensionContext, includDep
             const action = {database: table.target.database, schema: table.target.schema, name: table.target.name};
             actionsList.push(action);
         });
+
+        propertyGraphs.forEach((graph) => {
+            actionsList.push({database: graph.target.database, schema: graph.target.schema, name: graph.target.name});
+        });
+
+        if (actionsList.length === 0) {
+            vscode.window.showErrorMessage(`No runnable Dataform actions found in ${relativeFilePath}`);
+            return;
+        }
 
         const invocationConfig = {
             includedTargets: actionsList,

--- a/src/shared/propertyGraph.ts
+++ b/src/shared/propertyGraph.ts
@@ -165,6 +165,9 @@ export function knownPropertyNames(
     return (label?.fields ?? []).map((field) => field.name);
 }
 
+/** Row cap on generated starter queries; shared so the query and its explanation agree. */
+export const DEFAULT_GQL_ROW_LIMIT = 100;
+
 export interface GqlAliasMap {
     source: string;
     edge: string;
@@ -237,7 +240,7 @@ export function buildGqlQuery(
     graph: PropertyGraph,
     spec: GqlQuerySpec,
     selection: GqlSelection,
-    rowLimit = 100,
+    rowLimit = DEFAULT_GQL_ROW_LIMIT,
 ): string {
     const graphName = fullTargetName(graph.target);
     const pattern =
@@ -245,15 +248,14 @@ export function buildGqlQuery(
         + `-[${spec.aliases.edge}:${spec.relationshipName}]->`
         + `(${spec.aliases.destination}:${spec.destinationEntityName})`;
 
-    const aliasByElement: Record<string, string> = {
-        [spec.sourceEntityName]: spec.aliases.source,
-        [spec.relationshipName]: spec.aliases.edge,
-        [spec.destinationEntityName]: spec.aliases.destination,
-    };
+    const parts: { elementName: string; alias: string }[] = [
+        { elementName: spec.sourceEntityName, alias: spec.aliases.source },
+        { elementName: spec.relationshipName, alias: spec.aliases.edge },
+        { elementName: spec.destinationEntityName, alias: spec.aliases.destination },
+    ];
 
     const returnItems: string[] = [];
-    for (const elementName of [spec.sourceEntityName, spec.relationshipName, spec.destinationEntityName]) {
-        const alias = aliasByElement[elementName];
+    for (const { elementName, alias } of parts) {
         for (const property of selection[elementName] ?? []) {
             const item = `${alias}.${property}`;
             if (!returnItems.includes(item)) {

--- a/src/shared/propertyGraph.ts
+++ b/src/shared/propertyGraph.ts
@@ -1,0 +1,277 @@
+import type {
+    DataformCompiledJson,
+    PropertyGraph,
+    PropertyGraphEntity,
+    PropertyGraphLabel,
+    PropertyGraphRelationship,
+    PropertyGraphValidation,
+    Target,
+} from "../types";
+
+/**
+ * Pure helpers shared between the extension host and the preview webview.
+ * Must stay free of `vscode` imports so the webview bundle can import it.
+ */
+
+/** PropertyGraph actions first appear in the compiled graph in this version. */
+export const PROPERTY_GRAPHS_MIN_CORE_VERSION = "3.0.65";
+
+/**
+ * The wrapper we put around `graphBody` to get something BigQuery will parse.
+ *
+ * The compiler only hands us the `NODE TABLES (...) EDGE TABLES (...)` body, never a
+ * runnable statement, so this header is our reconstruction rather than Dataform's own.
+ * It is deliberately the only place the wrapper exists, it is always shown to the user
+ * alongside any validation result, and a failure attributed to these lines is reported
+ * as an extension problem instead of a problem with the user's graph.
+ *
+ * Verified against @dataform/core 3.0.69.
+ */
+const CREATE_STATEMENT_HEADER = (targetName: string) =>
+    `CREATE OR REPLACE PROPERTY GRAPH \`${targetName}\``;
+
+export function fullTargetName(target: Target): string {
+    return `${target.database}.${target.schema}.${target.name}`;
+}
+
+function parseSemver(version: string): number[] {
+    return version
+        .replace(/^[^0-9]*/, "")
+        .split(".")
+        .map((part) => parseInt(part, 10) || 0);
+}
+
+/** True when `version` is greater than or equal to `minimum`. Unknown versions are optimistic. */
+export function isCoreVersionAtLeast(version: string | undefined, minimum: string): boolean {
+    if (!version) {
+        return true;
+    }
+    const actual = parseSemver(version);
+    const required = parseSemver(minimum);
+    for (let i = 0; i < required.length; i++) {
+        const a = actual[i] ?? 0;
+        const r = required[i] ?? 0;
+        if (a !== r) {
+            return a > r;
+        }
+    }
+    return true;
+}
+
+/**
+ * Files that could hold a property graph definition. Used to decide whether an empty
+ * compiled result deserves the "your core is too old" hint rather than a generic error.
+ */
+export function isPropertyGraphCandidateFile(relativeFilePath: string | undefined): boolean {
+    if (!relativeFilePath) {
+        return false;
+    }
+    const normalised = relativeFilePath.replace(/\\/g, "/");
+    if (!normalised.endsWith(".yaml") && !normalised.endsWith(".yml")) {
+        return false;
+    }
+    // workflow_settings.yaml is a config file and handled elsewhere
+    if (normalised.split("/").pop()?.startsWith("workflow_settings")) {
+        return false;
+    }
+    return normalised.startsWith("definitions/") || normalised.includes("/definitions/");
+}
+
+export function getPropertyGraphsForFile(
+    relativeFilePath: string | undefined,
+    compiledJson: DataformCompiledJson | undefined,
+): PropertyGraph[] {
+    if (!relativeFilePath || !compiledJson?.propertyGraphs) {
+        return [];
+    }
+    const normalised = relativeFilePath.replace(/\\/g, "/");
+    return compiledJson.propertyGraphs.filter(
+        (graph) => graph.fileName?.replace(/\\/g, "/") === normalised,
+    );
+}
+
+/**
+ * Synthesise the statement used to validate a graph. `bodyStartLine` is the 1-indexed
+ * line of `statement` where `graphBody` begins, so a BigQuery error location can be
+ * mapped back onto the body the user actually wrote.
+ */
+export function buildPropertyGraphCreateStatement(graph: PropertyGraph): {
+    statement: string;
+    bodyStartLine: number;
+} {
+    const header = CREATE_STATEMENT_HEADER(fullTargetName(graph.target));
+    const headerLineCount = header.split("\n").length;
+    return {
+        statement: `${header}\n${graph.graphBody ?? ""}`,
+        bodyStartLine: headerLineCount + 1,
+    };
+}
+
+/**
+ * Turn a BigQuery dry run failure into something attributable. Errors landing on the
+ * synthesised header are ours, not the user's, and are flagged as such.
+ */
+export function classifyPropertyGraphDryRunError(
+    bodyStartLine: number,
+    message: string,
+    errorLine: number | undefined,
+): Pick<PropertyGraphValidation, "message" | "graphBodyLine" | "harnessError"> {
+    const mentionsWrapper = /\b(CREATE|PROPERTY GRAPH)\b/i.test(message)
+        && /syntax error|unexpected|not supported/i.test(message);
+    const landsOnHeader = errorLine !== undefined && errorLine > 0 && errorLine < bodyStartLine;
+
+    if (landsOnHeader || (mentionsWrapper && errorLine === undefined)) {
+        return {
+            message,
+            harnessError: true,
+        };
+    }
+
+    return {
+        message,
+        graphBodyLine: errorLine && errorLine >= bodyStartLine ? errorLine - bodyStartLine + 1 : undefined,
+        harnessError: false,
+    };
+}
+
+export function defaultLabelOf(
+    element: PropertyGraphEntity | PropertyGraphRelationship,
+): PropertyGraphLabel | undefined {
+    return element.labels?.find((label) => label.isDefault) ?? element.labels?.[0];
+}
+
+/** True when the element exposes every column of its backing table as a property. */
+export function elementImportsAllColumns(
+    element: PropertyGraphEntity | PropertyGraphRelationship,
+): boolean {
+    return defaultLabelOf(element)?.importAll === true;
+}
+
+/**
+ * Property names known from the compiled output alone, i.e. without reading the backing
+ * table's schema from BigQuery.
+ *
+ * For an `importAll` element the compiler tells us nothing about the columns, so the key
+ * columns are all we can name. For an element with explicit field mappings only the mapped
+ * names are exposed as properties — the key columns are not, unless they were mapped too.
+ */
+export function knownPropertyNames(
+    element: PropertyGraphEntity | PropertyGraphRelationship,
+): string[] {
+    const label = defaultLabelOf(element);
+    if (label?.importAll) {
+        return [...(element.keys ?? [])];
+    }
+    return (label?.fields ?? []).map((field) => field.name);
+}
+
+export interface GqlAliasMap {
+    source: string;
+    edge: string;
+    destination: string;
+}
+
+/** Element name -> selected property names, the single source of truth for the RETURN clause. */
+export type GqlSelection = Record<string, string[]>;
+
+export interface GqlQuerySpec {
+    relationshipName: string;
+    sourceEntityName: string;
+    destinationEntityName: string;
+    aliases: GqlAliasMap;
+    /**
+     * Selection the query starts from. Derived only from compiled output so it never
+     * changes underneath the user when a backing table's schema is read later.
+     */
+    defaultSelection: GqlSelection;
+}
+
+function aliasFor(name: string, taken: Set<string>): string {
+    const base = (name.match(/[a-zA-Z]/)?.[0] ?? "n").toLowerCase();
+    let candidate = base;
+    let suffix = 1;
+    while (taken.has(candidate)) {
+        candidate = `${base}${suffix++}`;
+    }
+    taken.add(candidate);
+    return candidate;
+}
+
+export function buildGqlQuerySpecs(graph: PropertyGraph): GqlQuerySpec[] {
+    const entitiesByName = new Map((graph.entities ?? []).map((entity) => [entity.name, entity]));
+
+    return (graph.relationships ?? []).map((relationship) => {
+        const source = entitiesByName.get(relationship.source?.entity);
+        const destination = entitiesByName.get(relationship.destination?.entity);
+
+        const taken = new Set<string>();
+        const aliases: GqlAliasMap = {
+            source: aliasFor(relationship.source?.entity ?? "source", taken),
+            edge: aliasFor(relationship.name, taken),
+            destination: aliasFor(relationship.destination?.entity ?? "destination", taken),
+        };
+
+        const defaultSelection: GqlSelection = {};
+        if (source) { defaultSelection[source.name] = knownPropertyNames(source); }
+        defaultSelection[relationship.name] = knownPropertyNames(relationship);
+        if (destination && destination.name !== source?.name) {
+            defaultSelection[destination.name] = knownPropertyNames(destination);
+        }
+
+        return {
+            relationshipName: relationship.name,
+            sourceEntityName: relationship.source?.entity ?? "",
+            destinationEntityName: relationship.destination?.entity ?? "",
+            aliases,
+            defaultSelection,
+        };
+    });
+}
+
+/**
+ * Render a runnable starter query. The RETURN clause is a pure function of `selection`,
+ * so reading a backing table's schema can never rewrite a query on its own — only an
+ * explicit change to the selection does.
+ */
+export function buildGqlQuery(
+    graph: PropertyGraph,
+    spec: GqlQuerySpec,
+    selection: GqlSelection,
+    rowLimit = 100,
+): string {
+    const graphName = fullTargetName(graph.target);
+    const pattern =
+        `(${spec.aliases.source}:${spec.sourceEntityName})`
+        + `-[${spec.aliases.edge}:${spec.relationshipName}]->`
+        + `(${spec.aliases.destination}:${spec.destinationEntityName})`;
+
+    const aliasByElement: Record<string, string> = {
+        [spec.sourceEntityName]: spec.aliases.source,
+        [spec.relationshipName]: spec.aliases.edge,
+        [spec.destinationEntityName]: spec.aliases.destination,
+    };
+
+    const returnItems: string[] = [];
+    for (const elementName of [spec.sourceEntityName, spec.relationshipName, spec.destinationEntityName]) {
+        const alias = aliasByElement[elementName];
+        for (const property of selection[elementName] ?? []) {
+            const item = `${alias}.${property}`;
+            if (!returnItems.includes(item)) {
+                returnItems.push(item);
+            }
+        }
+    }
+
+    // A RETURN clause is mandatory; fall back to a constant rather than emitting invalid GQL.
+    const returnClause = returnItems.length > 0 ? returnItems.join(", ") : "1 AS matched";
+
+    return [
+        "SELECT *",
+        "FROM GRAPH_TABLE(",
+        `  \`${graphName}\``,
+        `  MATCH ${pattern}`,
+        `  RETURN ${returnClause}`,
+        ")",
+        `LIMIT ${rowLimit}`,
+    ].join("\n");
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,6 +110,71 @@ export interface PropertyGraph {
     description?: string;
     graphBody?: string;
     disabled?: boolean;
+    entities?: PropertyGraphEntity[];
+    relationships?: PropertyGraphRelationship[];
+}
+
+/** A column of the backing table exposed as a graph property. */
+export interface PropertyGraphFieldMapping {
+    /** Property name as exposed to GQL. */
+    name: string;
+    /** Column (or expression) on the backing table it maps to. */
+    expression: string;
+}
+
+export interface PropertyGraphLabel {
+    name: string;
+    description?: string;
+    fields?: PropertyGraphFieldMapping[];
+    /** True when the yaml used `fieldWildcard.importAll`, in which case `fields` is absent. */
+    importAll?: boolean;
+    isDefault?: boolean;
+}
+
+export interface PropertyGraphEntity {
+    name: string;
+    dataSource: Target;
+    keys: string[];
+    labels: PropertyGraphLabel[];
+}
+
+export interface PropertyGraphRelationshipEnd {
+    entity: string;
+    relationshipColumns: string[];
+    entityColumns: string[];
+}
+
+export interface PropertyGraphRelationship {
+    name: string;
+    dataSource: Target;
+    keys: string[];
+    source: PropertyGraphRelationshipEnd;
+    destination: PropertyGraphRelationshipEnd;
+    labels: PropertyGraphLabel[];
+}
+
+/** Outcome of dry running the synthesised CREATE PROPERTY GRAPH statement. */
+export interface PropertyGraphValidation {
+    targetName: string;
+    /** The exact SQL that was dry run, always surfaced so the check is never a black box. */
+    statement: string;
+    state: "ok" | "error" | "skipped";
+    message?: string;
+    /** Line within `graphBody` the error points at, when it could be attributed. */
+    graphBodyLine?: number;
+    /**
+     * True when the failure looks like it is in the wrapper this extension synthesises
+     * rather than in the user's graph body.
+     */
+    harnessError?: boolean;
+}
+
+/** Columns read back from BigQuery for an entity/relationship backing table. */
+export interface PropertyGraphElementSchema {
+    elementName: string;
+    fullTableId: string;
+    columns: { name: string; type: string; description?: string }[];
+    error?: string;
 }
 
 export interface ProjectConfig {

--- a/src/views/register-preview-compiled-panel.ts
+++ b/src/views/register-preview-compiled-panel.ts
@@ -16,6 +16,53 @@ import * as fs from 'fs';
 import { debounce } from "../debounce";
 import { DataformTools } from "@ashishalex/dataform-tools";
 import { parseCompilationStack } from "../parseCompilationStack";
+import { queryDryRun, getLineAndColumnNumberFromErrorMessage } from "../bigqueryDryRun";
+import {
+    PROPERTY_GRAPHS_MIN_CORE_VERSION,
+    buildPropertyGraphCreateStatement,
+    classifyPropertyGraphDryRunError,
+    fullTargetName,
+    getPropertyGraphsForFile,
+    isCoreVersionAtLeast,
+    isPropertyGraphCandidateFile,
+} from "../shared/propertyGraph";
+import type { PropertyGraph, PropertyGraphValidation, PropertyGraphElementSchema } from "../types";
+
+/**
+ * Dry run the statement we synthesise for each graph and post the outcome back.
+ * Disabled graphs are skipped: Dataform will not execute them, so validating them
+ * would report failures for something that is never run.
+ */
+async function validatePropertyGraphs(webview: vscode.Webview, propertyGraphs: PropertyGraph[]) {
+    const validations: PropertyGraphValidation[] = await Promise.all(
+        propertyGraphs.map(async (graph): Promise<PropertyGraphValidation> => {
+            const targetName = fullTargetName(graph.target);
+            const { statement, bodyStartLine } = buildPropertyGraphCreateStatement(graph);
+
+            if (graph.disabled) {
+                return { targetName, statement, state: "skipped", message: "Graph is disabled, validation skipped" };
+            }
+            if (!graph.graphBody) {
+                return { targetName, statement, state: "skipped", message: "Compiler did not emit a graph body for this action" };
+            }
+
+            const dryRunResult = await queryDryRun(statement);
+            if (dryRunResult.error?.hasError) {
+                const message = dryRunResult.error.message ?? "Unknown BigQuery error";
+                const { line } = getLineAndColumnNumberFromErrorMessage(message);
+                return {
+                    targetName,
+                    statement,
+                    state: "error",
+                    ...classifyPropertyGraphDryRunError(bodyStartLine, message, line || undefined),
+                };
+            }
+            return { targetName, statement, state: "ok" };
+        }),
+    );
+
+    await webview.postMessage({ "propertyGraphValidations": validations, "dryRunning": false });
+}
 
 async function updateSchemaAutoCompletions(currentFileMetadata:any) {
     let allSchemaCompletions: SchemaMetadata[] = [];
@@ -79,7 +126,10 @@ export function registerCompiledQueryPanel(context: ExtensionContext) {
         const fileName = path.basename(document.fileName, '.' + fileExtension);
         const isConfigFile = fileName === 'workflow_settings' || fileName === 'dataform' || (fileName === 'package' && fileExtension === 'json');
         
-        if (fileExtension && !(fileExtension === 'sqlx' || fileExtension === 'js' || isConfigFile)) {
+        // definitions/**/*.yaml can hold a property graph, which the panel renders, so a save
+        // there has to refresh like a .sqlx save does.
+        const isDefinitionsYaml = isPropertyGraphCandidateFile(getRelativePath(document.fileName));
+        if (fileExtension && !(fileExtension === 'sqlx' || fileExtension === 'js' || isConfigFile || isDefinitionsYaml)) {
             return;
         }
         activeEditorFileName = document?.fileName;
@@ -213,7 +263,10 @@ export class CompiledQueryPanel {
         this.centerPanel?.webviewPanel.webview.onDidReceiveMessage(
           async message => {
             const now = Date.now();
-            if(this.centerPanel){
+            // Schema requests are per-element, idempotent and user driven. Letting the debounce
+            // hack below swallow them would leave an expanded node stuck on its spinner.
+            const exemptFromDebounce = message.command === 'propertyGraphElementSchema';
+            if(this.centerPanel && !exemptFromDebounce){
                 if (now - this?.centerPanel?.lastMessageTime < this?.centerPanel?.DEBOUNCE_INTERVAL) {
                     // NOTE: vscode.postMessage form webview sends in multiple messages when active editor is switched
                     // NOTE: This is debounce hack build to avoid processing multiple messages and process only the first message
@@ -639,6 +692,37 @@ export class CompiledQueryPanel {
                     });
                 }
                 return;
+              case 'propertyGraphElementSchema': {
+                const { elementName, target } = message.value ?? {};
+                if (!elementName || !target) {
+                    return;
+                }
+                const fullTableId = `${target.database}.${target.schema}.${target.name}`;
+                const columns = await getTableSchema(target.database, target.schema, target.name);
+                const elementSchema: PropertyGraphElementSchema = {
+                    elementName,
+                    fullTableId,
+                    columns: columns.map((column) => ({
+                        name: column.name,
+                        type: column.metadata?.type ?? "",
+                        description: column.metadata?.description,
+                    })),
+                    // getTableSchema swallows its errors and returns [], so an empty result is
+                    // the only signal available that the table could not be read.
+                    error: columns.length === 0 ? `Could not read the schema of ${fullTableId}` : undefined,
+                };
+                await this.centerPanel?.webviewPanel.webview.postMessage({
+                    "propertyGraphElementSchema": elementSchema,
+                });
+                return;
+              }
+              case 'runGeneratedQuery':
+                await vscode.commands.executeCommand(
+                    'vscode-dataform-tools.runGeneratedQuery',
+                    message.value?.query,
+                    message.value?.type ?? "table",
+                );
+                return;
               case 'openExternal':
                 if(message.url){
                     vscode.env.openExternal(vscode.Uri.parse(message.url));
@@ -863,6 +947,79 @@ export class CompiledQueryPanel {
             });
             return;
         }
+        // PropertyGraph actions live in yaml files that produce no queries, so they never
+        // reach the table/assertion/operation pipeline below and would otherwise render as
+        // an empty panel.
+        const relativeFilePathForGraphs = curFileMeta.pathMeta?.relativeFilePath;
+        if (isPropertyGraphCandidateFile(relativeFilePathForGraphs)) {
+            const propertyGraphs = getPropertyGraphsForFile(relativeFilePathForGraphs, CACHED_COMPILED_DATAFORM_JSON);
+
+            if (propertyGraphs.length > 0) {
+                if (diagnosticCollection) {
+                    diagnosticCollection.clear();
+                }
+                await webview.postMessage({
+                    "propertyGraphs": propertyGraphs,
+                    "propertyGraphValidations": null,
+                    "relativeFilePath": relativeFilePathForGraphs,
+                    "compilationTimeMs": curFileMeta.compilationTimeMs,
+                    "dataformTags": dataformTags,
+                    "dataformCoreVersion": curFileMeta.dataformCoreVersion,
+                    "compilerOptions": compilerOptions,
+                    "workflowUrls": workflowUrls,
+                    "workspaceFolder": workspaceFolder,
+                    "recompiling": false,
+                    "dryRunning": true,
+                    "errorType": null,
+                    "errorMessage": null,
+                    "isHelperFile": false,
+                    "declarations": null,
+                    "models": null,
+                    "tableOrViewQuery": null,
+                    "assertionQuery": null,
+                    "preOperations": null,
+                    "postOperations": null,
+                    "incrementalPreOpsQuery": null,
+                    "incrementalQuery": null,
+                    "nonIncrementalQuery": null,
+                    "operationsQuery": null,
+                    "testQuery": null,
+                    "expectedOutputQuery": null,
+                    "projectConfig": null,
+                    "packageJsonContent": null,
+                    "compiledQuerySchema": null,
+                });
+
+                // Validation is a network round trip; do not hold up the render for it.
+                validatePropertyGraphs(webview, propertyGraphs).catch((error) => {
+                    logger.error(`Error validating property graphs: ${error}`);
+                });
+                return;
+            }
+
+            const coreVersion = curFileMeta.dataformCoreVersion ?? CACHED_COMPILED_DATAFORM_JSON?.dataformCoreVersion;
+            if (!isCoreVersionAtLeast(coreVersion, PROPERTY_GRAPHS_MIN_CORE_VERSION)) {
+                await webview.postMessage({
+                    "errorMessage": `Property graphs require @dataform/core ${PROPERTY_GRAPHS_MIN_CORE_VERSION} or later. This project is on ${coreVersion}, so the compiled output contains no propertyGraphs for this file.`,
+                    "errorType": CompilationErrorType.COMPILATION_ERROR,
+                    "relativeFilePath": relativeFilePathForGraphs,
+                    "dataformCoreVersion": coreVersion,
+                    "recompiling": false,
+                    "dryRunning": false,
+                    "isHelperFile": false,
+                    "propertyGraphs": null,
+                    "models": null,
+                    "declarations": null,
+                    "tableOrViewQuery": null,
+                    "projectConfig": null,
+                    "packageJsonContent": null,
+                    "compiledQuerySchema": null,
+                    "workspaceFolder": workspaceFolder,
+                });
+                return;
+            }
+        }
+
         const isJs = curFileMeta && curFileMeta.pathMeta && curFileMeta.pathMeta.extension === "js";
         
         updateSchemaAutoCompletions(curFileMeta);
@@ -880,6 +1037,7 @@ export class CompiledQueryPanel {
                             }
                             await webview.postMessage({
                                 "declarations": filteredDeclarations,
+                                "propertyGraphs": null,
                                 "recompiling": false,
                                 "errorType": null,
                                 "errorMessage": null,
@@ -894,6 +1052,7 @@ export class CompiledQueryPanel {
                     // If it's a JS file but has no tables and no declarations, it's a helper file
                     await webview.postMessage({
                         "isHelperFile": true,
+                        "propertyGraphs": null,
                         "recompiling": false,
                         "relativeFilePath": curFileMeta.pathMeta?.relativeFilePath,
                         "errorType": null,
@@ -956,6 +1115,7 @@ export class CompiledQueryPanel {
             "modelType": fileMetadata.queryMeta.type,
             "actionTypes": [...new Set((fm.tables || []).map((m: any) => m.type).filter(Boolean))],
             "models": fm.tables,
+            "propertyGraphs": null,
             "recompiling": false,
             "dryRunning": true,
             "declarations": null,

--- a/webviews/preview_compiled/App.tsx
+++ b/webviews/preview_compiled/App.tsx
@@ -85,6 +85,10 @@ function App() {
 
   const isConfigFile = state.relativeFilePath === 'workflow_settings.yaml' || state.relativeFilePath === 'dataform.json' || state.relativeFilePath === 'package.json';
 
+  // Property graphs have no output schema, no bytes-scanned estimate and no compiled query,
+  // so the panel collapses to a single tab for them.
+  const isPropertyGraphFile = (state.propertyGraphs?.length ?? 0) > 0;
+
   useEffect(() => {
     const observer = new MutationObserver((mutations) => {
       mutations.forEach((mutation) => {
@@ -139,10 +143,10 @@ function App() {
   useEffect(() => {
     if (state.relativeFilePath === 'workflow_settings.yaml' || state.relativeFilePath === 'dataform.json' || state.relativeFilePath === 'package.json') {
       setActiveTab('project_config');
-    } else if (activeTab === 'project_config') {
+    } else if (activeTab === 'project_config' || (isPropertyGraphFile && activeTab !== 'compilation')) {
       setActiveTab('compilation');
     }
-  }, [state.relativeFilePath, activeTab]);
+  }, [state.relativeFilePath, activeTab, isPropertyGraphFile]);
 
   // Handle declarations view (full page override)
   if (state.declarations) {
@@ -169,6 +173,8 @@ function App() {
               >
                 Compiled Query
               </button>
+              {!isPropertyGraphFile && (
+              <>
               <button
                 onClick={() => setActiveTab('schema')}
                 className={clsx(
@@ -202,6 +208,8 @@ function App() {
               >
                 Workflow Executions
               </button>
+              </>
+              )}
             </div>
             <HeaderRightActions />
           </>
@@ -248,7 +256,7 @@ function App() {
             <SkeletonLoader type={isConfigFile ? 'config' : 'default'} />
         )}
 
-{(state.errorType === CompilationErrorType.COMPILATION_ERROR ||
+{!isPropertyGraphFile && (state.errorType === CompilationErrorType.COMPILATION_ERROR ||
           !state.models?.length ||
           (state.missingExecutables && state.missingExecutables.length > 0)) && (
           <CompilationError state={state} />
@@ -264,6 +272,7 @@ function App() {
         )}
 
         {!isConfigFile && !state.isHelperFile && activeTab === 'compilation' && (
+          isPropertyGraphFile ||
           state.tableOrViewQuery ||
           state.operationsQuery ||
           state.assertionQuery ||
@@ -273,9 +282,9 @@ function App() {
           state.declarations ||
           state.models?.some((m: any) => m.type === 'notebook')
         ) && <CompiledQueryTab state={state} />}
-        {!isConfigFile && !state.isHelperFile && activeTab === 'schema' && <SchemaTab state={state} />}
-        {!isConfigFile && !state.isHelperFile && activeTab === 'cost' && <CostEstimatorTab state={state} />}
-        {!isConfigFile && !state.isHelperFile && activeTab === 'workflow_urls' && <WorkflowURLsTab state={state} isPolling={isPolling} />}
+        {!isConfigFile && !state.isHelperFile && !isPropertyGraphFile && activeTab === 'schema' && <SchemaTab state={state} />}
+        {!isConfigFile && !state.isHelperFile && !isPropertyGraphFile && activeTab === 'cost' && <CostEstimatorTab state={state} />}
+        {!isConfigFile && !state.isHelperFile && !isPropertyGraphFile && activeTab === 'workflow_urls' && <WorkflowURLsTab state={state} isPolling={isPolling} />}
 
       </div>
     </div>

--- a/webviews/preview_compiled/components/CompiledQueryTab.tsx
+++ b/webviews/preview_compiled/components/CompiledQueryTab.tsx
@@ -25,6 +25,7 @@ import { BigQueryTableLink } from "../../components/BigQueryTableLink";
 import { ACTION_TYPE_BADGE_STYLES, DEFAULT_BADGE_STYLE } from "../utils/constants";
 import * as RadixTabs from "@radix-ui/react-tabs";
 import { CompilerOverrides } from "./CompilerOverrides";
+import { PropertyGraphSection } from "./PropertyGraphSection";
 import StyledMultiSelect from "../../dependancy_graph/components/StyledMultiSelect";
 import { OptionType } from "../../dependancy_graph/components/StyledSelect";
 import { MultiValue } from "react-select";
@@ -222,6 +223,26 @@ export const CompiledQueryTab: React.FC<CompiledQueryTabProps> = ({
     if (type === 'operations') {return 'Operations';};
     return 'Query';
   };
+
+  // Property graphs produce no query, so none of the toolbar below (format, lint, preview,
+  // dry run stats) applies to them. They get their own section instead.
+  if ((state.propertyGraphs?.length ?? 0) > 0) {
+    return (
+      <div className="space-y-6 pb-20">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-sm font-mono text-[var(--vscode-descriptionForeground)] bg-[var(--vscode-editor-background)] border border-[var(--vscode-widget-border)] px-2 py-1 rounded">
+            {state.relativeFilePath || " "}
+          </span>
+          {state.compilationTimeMs !== undefined && state.recompiling === false && (
+            <span className="text-xs text-[var(--vscode-descriptionForeground)]">
+              Compiled in {(state.compilationTimeMs / 1000).toFixed(2)}s
+            </span>
+          )}
+        </div>
+        <PropertyGraphSection state={state} />
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-6">

--- a/webviews/preview_compiled/components/PropertyGraphDiagram.tsx
+++ b/webviews/preview_compiled/components/PropertyGraphDiagram.tsx
@@ -182,6 +182,7 @@ const ElementNode: React.FC<NodeProps> = ({ data }) => {
 
 const EDGE_LABEL_WIDTH = 220;
 const EDGE_LABEL_HEIGHT = 64;
+const SELF_LOOP_HEIGHT = 110;
 
 type RelationshipEdgeData = { name: string };
 
@@ -191,14 +192,25 @@ type RelationshipEdgeData = { name: string };
  * table became the arrow — which is the one idea the whole property graph model rests on.
  */
 const RelationshipEdge: React.FC<EdgeProps> = ({
-  id, sourceX, sourceY, targetX, targetY, sourcePosition, targetPosition, markerEnd, data,
+  id, source, target, sourceX, sourceY, targetX, targetY, sourcePosition, targetPosition, markerEnd, data,
 }) => {
   const { name } = data as unknown as RelationshipEdgeData;
   const { relationshipByName, selection, onSelectRelationship } = useDiagramContext();
   const relationship = relationshipByName[name];
-  const [edgePath, labelX, labelY] = getSmoothStepPath({
+
+  // A relationship may start and end at the same entity. The built in path helpers collapse to
+  // nothing in that case, which would drop the relationship from the diagram entirely, so a
+  // loop is drawn over the node instead.
+  const isSelfLoop = source === target;
+  const loopApexY = sourceY - SELF_LOOP_HEIGHT;
+  const [smoothPath, smoothLabelX, smoothLabelY] = getSmoothStepPath({
     sourceX, sourceY, sourcePosition, targetX, targetY, targetPosition, borderRadius: 8,
   });
+  const edgePath = isSelfLoop
+    ? `M ${sourceX},${sourceY} C ${sourceX + 70},${loopApexY} ${targetX - 70},${loopApexY} ${targetX},${targetY}`
+    : smoothPath;
+  const labelX = isSelfLoop ? (sourceX + targetX) / 2 : smoothLabelX;
+  const labelY = isSelfLoop ? loopApexY + SELF_LOOP_HEIGHT / 3 : smoothLabelY;
 
   return (
     <>

--- a/webviews/preview_compiled/components/PropertyGraphDiagram.tsx
+++ b/webviews/preview_compiled/components/PropertyGraphDiagram.tsx
@@ -1,0 +1,247 @@
+import React, { useMemo } from "react";
+import {
+  Background,
+  Controls,
+  Handle,
+  Position,
+  ReactFlow,
+  type Edge,
+  type Node,
+  type NodeProps,
+} from "@xyflow/react";
+import dagre from "dagre";
+import { ChevronDown, ChevronRight, KeyRound, Loader2, AlertTriangle } from "lucide-react";
+import clsx from "clsx";
+import { BigQueryTableLink } from "../../components/BigQueryTableLink";
+
+export type SchemaState = "idle" | "loading" | "loaded" | "error";
+
+export interface GraphElementView {
+  kind: "entity" | "relationship";
+  name: string;
+  backingTable: string;
+  keys: string[];
+  importAll: boolean;
+  mappedFields: { name: string; expression: string }[];
+  /** Property names the user can pick from, growing once a backing schema has been read. */
+  availableProperties: string[];
+  schemaState: SchemaState;
+  schemaError?: string;
+}
+
+export interface PropertyGraphDiagramProps {
+  entities: GraphElementView[];
+  edges: { relationship: GraphElementView; source: string; destination: string }[];
+  expanded: Record<string, boolean>;
+  selection: Record<string, string[]>;
+  onToggleExpand: (elementName: string) => void;
+  onToggleProperty: (elementName: string, property: string) => void;
+}
+
+const NODE_WIDTH = 280;
+const COLLAPSED_HEIGHT = 96;
+
+function nodeHeight(element: GraphElementView, isExpanded: boolean): number {
+  if (!isExpanded) {
+    return COLLAPSED_HEIGHT;
+  }
+  const rows = Math.max(element.availableProperties.length, 1);
+  return Math.min(COLLAPSED_HEIGHT + 44 + rows * 24, 380);
+}
+
+export const PropertyList: React.FC<{
+  element: GraphElementView;
+  selected: string[];
+  onToggleProperty: (elementName: string, property: string) => void;
+}> = ({ element, selected, onToggleProperty }) => {
+  const expressionByName = new Map(element.mappedFields.map((field) => [field.name, field.expression]));
+
+  if (element.schemaState === "loading") {
+    return (
+      <div className="flex items-center gap-2 text-xs text-[var(--vscode-descriptionForeground)] py-2">
+        <Loader2 className="w-3 h-3 animate-spin" /> Reading {element.backingTable}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-1">
+      {element.schemaState === "error" && (
+        <div className="flex items-start gap-1.5 text-[11px] text-[var(--vscode-errorForeground)] pb-1">
+          <AlertTriangle className="w-3 h-3 mt-0.5 flex-shrink-0" />
+          <span>{element.schemaError}</span>
+        </div>
+      )}
+      {element.availableProperties.length === 0 && element.schemaState !== "error" && (
+        <div className="text-[11px] text-[var(--vscode-descriptionForeground)]">
+          No properties exposed by this element.
+        </div>
+      )}
+      {element.availableProperties.map((property) => {
+        const isKey = element.keys.includes(property);
+        const expression = expressionByName.get(property);
+        return (
+          <label
+            key={property}
+            className="flex items-center gap-2 text-[11px] font-mono cursor-pointer hover:bg-[var(--vscode-toolbar-hoverBackground)] rounded px-1 py-0.5"
+          >
+            <input
+              type="checkbox"
+              className="accent-[var(--vscode-button-background)] w-3 h-3 flex-shrink-0"
+              checked={selected.includes(property)}
+              onChange={() => onToggleProperty(element.name, property)}
+            />
+            {isKey && <KeyRound className="w-3 h-3 flex-shrink-0 text-[var(--vscode-charts-yellow)]" />}
+            <span className="truncate text-[var(--vscode-foreground)]">{property}</span>
+            {expression && expression !== property && (
+              <span className="truncate opacity-50">&larr; {expression}</span>
+            )}
+          </label>
+        );
+      })}
+    </div>
+  );
+};
+
+type ElementNodeData = {
+  element: GraphElementView;
+  isExpanded: boolean;
+  selected: string[];
+  onToggleExpand: (elementName: string) => void;
+  onToggleProperty: (elementName: string, property: string) => void;
+};
+
+const ElementNode: React.FC<NodeProps> = ({ data }) => {
+  const { element, isExpanded, selected, onToggleExpand, onToggleProperty } = data as unknown as ElementNodeData;
+
+  return (
+    <div
+      className="rounded-lg border border-[var(--vscode-widget-border)] bg-[var(--vscode-sideBar-background)] shadow-sm"
+      style={{ width: NODE_WIDTH }}
+    >
+      <Handle type="target" position={Position.Left} className="!bg-[var(--vscode-charts-blue)]" />
+      <button
+        type="button"
+        onClick={() => onToggleExpand(element.name)}
+        className="nodrag w-full text-left px-3 py-2 flex items-start gap-1.5 hover:bg-[var(--vscode-toolbar-hoverBackground)] rounded-t-lg"
+      >
+        {isExpanded ? (
+          <ChevronDown className="w-3.5 h-3.5 mt-0.5 flex-shrink-0 opacity-60" />
+        ) : (
+          <ChevronRight className="w-3.5 h-3.5 mt-0.5 flex-shrink-0 opacity-60" />
+        )}
+        <div className="min-w-0 flex-1">
+          <div className="text-sm font-semibold text-[var(--vscode-foreground)] truncate">{element.name}</div>
+          <div className="text-[10px] uppercase tracking-wider opacity-50">
+            {element.importAll ? "all columns" : `${element.mappedFields.length} properties`}
+            {" · "}
+            {selected.length} in query
+          </div>
+        </div>
+      </button>
+      <div className="nodrag px-3 pb-2 text-[10px]">
+        <BigQueryTableLink id={element.backingTable} className="font-mono text-[var(--vscode-textLink-foreground)] hover:underline break-all" />
+      </div>
+      {isExpanded && (
+        <div className="px-3 pb-3 max-h-64 overflow-auto border-t border-[var(--vscode-widget-border)]/60 pt-2 nodrag nowheel">
+          <PropertyList element={element} selected={selected} onToggleProperty={onToggleProperty} />
+        </div>
+      )}
+      <Handle type="source" position={Position.Right} className="!bg-[var(--vscode-charts-blue)]" />
+    </div>
+  );
+};
+
+const nodeTypes = { graphElement: ElementNode };
+
+export const PropertyGraphDiagram: React.FC<PropertyGraphDiagramProps> = ({
+  entities,
+  edges,
+  expanded,
+  selection,
+  onToggleExpand,
+  onToggleProperty,
+}) => {
+  const { flowNodes, flowEdges } = useMemo(() => {
+    const graph = new dagre.graphlib.Graph();
+    graph.setDefaultEdgeLabel(() => ({}));
+    graph.setGraph({ rankdir: "LR", nodesep: 48, ranksep: 140, marginx: 16, marginy: 16 });
+
+    entities.forEach((entity) => {
+      graph.setNode(entity.name, {
+        width: NODE_WIDTH,
+        height: nodeHeight(entity, expanded[entity.name] === true),
+      });
+    });
+    edges.forEach((edge) => {
+      if (graph.hasNode(edge.source) && graph.hasNode(edge.destination)) {
+        graph.setEdge(edge.source, edge.destination);
+      }
+    });
+
+    dagre.layout(graph);
+
+    const flowNodes: Node[] = entities.map((entity) => {
+      const position = graph.node(entity.name);
+      const height = nodeHeight(entity, expanded[entity.name] === true);
+      return {
+        id: entity.name,
+        type: "graphElement",
+        position: {
+          x: (position?.x ?? 0) - NODE_WIDTH / 2,
+          y: (position?.y ?? 0) - height / 2,
+        },
+        data: {
+          element: entity,
+          isExpanded: expanded[entity.name] === true,
+          selected: selection[entity.name] ?? [],
+          onToggleExpand,
+          onToggleProperty,
+        },
+      };
+    });
+
+    const flowEdges: Edge[] = edges.map((edge) => ({
+      id: `${edge.source}--${edge.relationship.name}--${edge.destination}`,
+      source: edge.source,
+      target: edge.destination,
+      label: edge.relationship.name,
+      animated: false,
+      style: { stroke: "var(--vscode-charts-blue)", strokeWidth: 1.5 },
+      labelStyle: { fill: "var(--vscode-foreground)", fontSize: 11 },
+      labelBgStyle: { fill: "var(--vscode-sideBar-background)" },
+      labelBgPadding: [4, 2] as [number, number],
+      labelBgBorderRadius: 4,
+      markerEnd: { type: "arrowclosed" as const, color: "var(--vscode-charts-blue)" },
+    }));
+
+    return { flowNodes, flowEdges };
+  }, [entities, edges, expanded, selection, onToggleExpand, onToggleProperty]);
+
+  if (entities.length === 0) {
+    return (
+      <div className="text-xs text-[var(--vscode-descriptionForeground)] px-3 py-6 text-center">
+        This graph declares no entities.
+      </div>
+    );
+  }
+
+  return (
+    <div className={clsx("h-[380px] w-full rounded-lg border border-[var(--vscode-widget-border)]/60 overflow-hidden")}>
+      <ReactFlow
+        nodes={flowNodes}
+        edges={flowEdges}
+        nodeTypes={nodeTypes}
+        fitView
+        proOptions={{ hideAttribution: true }}
+        minZoom={0.2}
+        nodesDraggable
+        nodesConnectable={false}
+        edgesFocusable={false}
+      >
+        <Background color="var(--vscode-widget-border)" gap={16} />
+        <Controls showInteractive={false} />
+      </ReactFlow>
+    </div>
+  );
+};

--- a/webviews/preview_compiled/components/PropertyGraphDiagram.tsx
+++ b/webviews/preview_compiled/components/PropertyGraphDiagram.tsx
@@ -1,11 +1,15 @@
-import React, { useMemo } from "react";
+import React, { createContext, useContext, useMemo } from "react";
 import {
+  BaseEdge,
   Background,
   Controls,
+  EdgeLabelRenderer,
   Handle,
   Position,
   ReactFlow,
+  getSmoothStepPath,
   type Edge,
+  type EdgeProps,
   type Node,
   type NodeProps,
 } from "@xyflow/react";
@@ -36,18 +40,13 @@ export interface PropertyGraphDiagramProps {
   selection: Record<string, string[]>;
   onToggleExpand: (elementName: string) => void;
   onToggleProperty: (elementName: string, property: string) => void;
+  /** Reveal a relationship's detail card, since an edge has nowhere to expand into. */
+  onSelectRelationship: (relationshipName: string) => void;
 }
 
 const NODE_WIDTH = 280;
 const COLLAPSED_HEIGHT = 96;
 
-function nodeHeight(element: GraphElementView, isExpanded: boolean): number {
-  if (!isExpanded) {
-    return COLLAPSED_HEIGHT;
-  }
-  const rows = Math.max(element.availableProperties.length, 1);
-  return Math.min(COLLAPSED_HEIGHT + 44 + rows * 24, 380);
-}
 
 export const PropertyList: React.FC<{
   element: GraphElementView;
@@ -103,16 +102,45 @@ export const PropertyList: React.FC<{
   );
 };
 
-type ElementNodeData = {
-  element: GraphElementView;
-  isExpanded: boolean;
-  selected: string[];
+/**
+ * Live diagram data is delivered through context rather than through `node.data`.
+ *
+ * React Flow rebuilds its internal node bookkeeping — measurements, handle bounds — whenever the
+ * `nodes` prop hands it new objects, and an endpoint without handle bounds means the edge is
+ * silently not drawn. Keeping the node array referentially stable and reading everything that
+ * changes (expansion, selection, callbacks) from context keeps that bookkeeping intact.
+ */
+interface DiagramContextValue {
+  elementByName: Record<string, GraphElementView>;
+  relationshipByName: Record<string, GraphElementView>;
+  expanded: Record<string, boolean>;
+  selection: Record<string, string[]>;
   onToggleExpand: (elementName: string) => void;
   onToggleProperty: (elementName: string, property: string) => void;
+  onSelectRelationship: (relationshipName: string) => void;
+}
+
+const DiagramContext = createContext<DiagramContextValue | null>(null);
+
+const useDiagramContext = () => {
+  const value = useContext(DiagramContext);
+  if (!value) {
+    throw new Error("Property graph diagram nodes must render inside DiagramContext");
+  }
+  return value;
 };
 
+type ElementNodeData = { name: string };
+
 const ElementNode: React.FC<NodeProps> = ({ data }) => {
-  const { element, isExpanded, selected, onToggleExpand, onToggleProperty } = data as unknown as ElementNodeData;
+  const { name } = data as unknown as ElementNodeData;
+  const { elementByName, expanded, selection, onToggleExpand, onToggleProperty } = useDiagramContext();
+  const element = elementByName[name];
+  if (!element) {
+    return null;
+  }
+  const isExpanded = expanded[name] === true;
+  const selected = selection[name] ?? [];
 
   return (
     <div
@@ -152,7 +180,58 @@ const ElementNode: React.FC<NodeProps> = ({ data }) => {
   );
 };
 
+const EDGE_LABEL_WIDTH = 220;
+const EDGE_LABEL_HEIGHT = 64;
+
+type RelationshipEdgeData = { name: string };
+
+/**
+ * The relationship's backing table is named on the edge itself. Without it a reader counts
+ * three tables in their yaml, two boxes in the diagram, and has no way to see that the third
+ * table became the arrow — which is the one idea the whole property graph model rests on.
+ */
+const RelationshipEdge: React.FC<EdgeProps> = ({
+  id, sourceX, sourceY, targetX, targetY, sourcePosition, targetPosition, markerEnd, data,
+}) => {
+  const { name } = data as unknown as RelationshipEdgeData;
+  const { relationshipByName, selection, onSelectRelationship } = useDiagramContext();
+  const relationship = relationshipByName[name];
+  const [edgePath, labelX, labelY] = getSmoothStepPath({
+    sourceX, sourceY, sourcePosition, targetX, targetY, targetPosition, borderRadius: 8,
+  });
+
+  return (
+    <>
+      <BaseEdge id={id} path={edgePath} markerEnd={markerEnd} style={{ stroke: "var(--vscode-charts-blue)", strokeWidth: 1.5 }} />
+      <EdgeLabelRenderer>
+        <button
+          type="button"
+          onClick={() => onSelectRelationship(name)}
+          title={`Show the ${name} relationship`}
+          className="nodrag nopan absolute rounded-md border border-[var(--vscode-widget-border)] bg-[var(--vscode-sideBar-background)] px-2 py-1 text-center hover:bg-[var(--vscode-toolbar-hoverBackground)]"
+          style={{
+            transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
+            maxWidth: EDGE_LABEL_WIDTH,
+            pointerEvents: "all",
+          }}
+        >
+          <div className="text-xs font-semibold text-[var(--vscode-foreground)] truncate">{name}</div>
+          <div className="text-[10px] font-mono text-[var(--vscode-descriptionForeground)] truncate">
+            {relationship ? (relationship.backingTable.split(".").pop() ?? relationship.backingTable) : ""}
+          </div>
+          <div className="text-[10px] uppercase tracking-wider opacity-50 truncate">
+            {relationship && (relationship.importAll ? "all columns" : `${relationship.mappedFields.length} properties`)}
+            {" · "}
+            {(selection[name] ?? []).length} in query
+          </div>
+        </button>
+      </EdgeLabelRenderer>
+    </>
+  );
+};
+
 const nodeTypes = { graphElement: ElementNode };
+const edgeTypes = { relationship: RelationshipEdge };
 
 export const PropertyGraphDiagram: React.FC<PropertyGraphDiagramProps> = ({
   entities,
@@ -161,62 +240,78 @@ export const PropertyGraphDiagram: React.FC<PropertyGraphDiagramProps> = ({
   selection,
   onToggleExpand,
   onToggleProperty,
+  onSelectRelationship,
 }) => {
-  const { flowNodes, flowEdges } = useMemo(() => {
+  // The set of boxes and arrows, as opposed to what they currently display. Only a change here
+  // may rebuild the node and edge objects; everything else reaches them through context.
+  const structureKey = useMemo(
+    () => [
+      entities.map((entity) => entity.name).join("|"),
+      edges.map((edge) => `${edge.source}>${edge.relationship.name}>${edge.destination}`).join("|"),
+    ].join("::"),
+    [entities, edges],
+  );
+
+  const layoutById = useMemo(() => {
     const graph = new dagre.graphlib.Graph();
     graph.setDefaultEdgeLabel(() => ({}));
-    graph.setGraph({ rankdir: "LR", nodesep: 48, ranksep: 140, marginx: 16, marginy: 16 });
+    graph.setGraph({ rankdir: "LR", nodesep: 120, ranksep: 220, marginx: 16, marginy: 16 });
 
     entities.forEach((entity) => {
-      graph.setNode(entity.name, {
-        width: NODE_WIDTH,
-        height: nodeHeight(entity, expanded[entity.name] === true),
-      });
+      graph.setNode(entity.name, { width: NODE_WIDTH, height: COLLAPSED_HEIGHT });
     });
     edges.forEach((edge) => {
       if (graph.hasNode(edge.source) && graph.hasNode(edge.destination)) {
-        graph.setEdge(edge.source, edge.destination);
+        graph.setEdge(edge.source, edge.destination, { width: EDGE_LABEL_WIDTH, height: EDGE_LABEL_HEIGHT });
       }
     });
-
     dagre.layout(graph);
 
-    const flowNodes: Node[] = entities.map((entity) => {
-      const position = graph.node(entity.name);
-      const height = nodeHeight(entity, expanded[entity.name] === true);
-      return {
-        id: entity.name,
-        type: "graphElement",
-        position: {
-          x: (position?.x ?? 0) - NODE_WIDTH / 2,
-          y: (position?.y ?? 0) - height / 2,
-        },
-        data: {
-          element: entity,
-          isExpanded: expanded[entity.name] === true,
-          selected: selection[entity.name] ?? [],
-          onToggleExpand,
-          onToggleProperty,
-        },
+    const positions: Record<string, { x: number; y: number }> = {};
+    entities.forEach((entity) => {
+      const laid = graph.node(entity.name);
+      positions[entity.name] = {
+        x: (laid?.x ?? 0) - NODE_WIDTH / 2,
+        y: (laid?.y ?? 0) - COLLAPSED_HEIGHT / 2,
       };
     });
+    return positions;
+    // Positions depend only on which boxes and arrows exist, never on what they display, so
+    // that reading a backing schema cannot shuffle the diagram under the reader.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [structureKey]);
 
-    const flowEdges: Edge[] = edges.map((edge) => ({
-      id: `${edge.source}--${edge.relationship.name}--${edge.destination}`,
-      source: edge.source,
-      target: edge.destination,
-      label: edge.relationship.name,
-      animated: false,
-      style: { stroke: "var(--vscode-charts-blue)", strokeWidth: 1.5 },
-      labelStyle: { fill: "var(--vscode-foreground)", fontSize: 11 },
-      labelBgStyle: { fill: "var(--vscode-sideBar-background)" },
-      labelBgPadding: [4, 2] as [number, number],
-      labelBgBorderRadius: 4,
-      markerEnd: { type: "arrowclosed" as const, color: "var(--vscode-charts-blue)" },
-    }));
+  const builtNodes = useMemo<Node[]>(() => entities.map((entity) => ({
+    id: entity.name,
+    type: "graphElement",
+    position: layoutById[entity.name] ?? { x: 0, y: 0 },
+    data: { name: entity.name },
+  })),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [structureKey, layoutById]);
 
-    return { flowNodes, flowEdges };
-  }, [entities, edges, expanded, selection, onToggleExpand, onToggleProperty]);
+  const builtEdges = useMemo<Edge[]>(() => edges.map((edge) => ({
+    id: `${edge.source}--${edge.relationship.name}--${edge.destination}`,
+    source: edge.source,
+    target: edge.destination,
+    type: "relationship",
+    animated: false,
+    markerEnd: { type: "arrowclosed" as const, color: "var(--vscode-charts-blue)" },
+    data: { name: edge.relationship.name },
+  })),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [structureKey]);
+
+
+  const contextValue = useMemo<DiagramContextValue>(() => ({
+    elementByName: Object.fromEntries(entities.map((entity) => [entity.name, entity])),
+    relationshipByName: Object.fromEntries(edges.map((edge) => [edge.relationship.name, edge.relationship])),
+    expanded,
+    selection,
+    onToggleExpand,
+    onToggleProperty,
+    onSelectRelationship,
+  }), [entities, edges, expanded, selection, onToggleExpand, onToggleProperty, onSelectRelationship]);
 
   if (entities.length === 0) {
     return (
@@ -227,21 +322,24 @@ export const PropertyGraphDiagram: React.FC<PropertyGraphDiagramProps> = ({
   }
 
   return (
-    <div className={clsx("h-[380px] w-full rounded-lg border border-[var(--vscode-widget-border)]/60 overflow-hidden")}>
-      <ReactFlow
-        nodes={flowNodes}
-        edges={flowEdges}
-        nodeTypes={nodeTypes}
-        fitView
-        proOptions={{ hideAttribution: true }}
-        minZoom={0.2}
-        nodesDraggable
-        nodesConnectable={false}
-        edgesFocusable={false}
-      >
-        <Background color="var(--vscode-widget-border)" gap={16} />
-        <Controls showInteractive={false} />
-      </ReactFlow>
-    </div>
+    <DiagramContext.Provider value={contextValue}>
+      <div className={clsx("h-[380px] w-full rounded-lg border border-[var(--vscode-widget-border)]/60 overflow-hidden")}>
+        <ReactFlow
+          nodes={builtNodes}
+          edges={builtEdges}
+          nodeTypes={nodeTypes}
+          edgeTypes={edgeTypes}
+          fitView
+          proOptions={{ hideAttribution: true }}
+          minZoom={0.2}
+          nodesDraggable={false}
+          nodesConnectable={false}
+          edgesFocusable={false}
+        >
+          <Background color="var(--vscode-widget-border)" gap={16} />
+          <Controls showInteractive={false} />
+        </ReactFlow>
+      </div>
+    </DiagramContext.Provider>
   );
 };

--- a/webviews/preview_compiled/components/PropertyGraphSection.tsx
+++ b/webviews/preview_compiled/components/PropertyGraphSection.tsx
@@ -22,6 +22,7 @@ import {
   elementImportsAllColumns,
   fullTargetName,
   knownPropertyNames,
+  type GqlQuerySpec,
   type GqlSelection,
 } from "../../../src/shared/propertyGraph";
 import { PropertyGraphDiagram, PropertyList, type GraphElementView } from "./PropertyGraphDiagram";
@@ -214,6 +215,99 @@ const RelationshipCard: React.FC<{
   </div>
 );
 
+/**
+ * A reader who has never used a graph database can follow the diagram but not the query, and
+ * GQL syntax gives no clue which bracket means what. This explains the generated query in
+ * terms of their own entity and relationship names, and ends on the join it is equivalent to,
+ * which is the bridge for someone who already thinks in SQL.
+ */
+const StarterQueryExplainer: React.FC<{
+  graph: PropertyGraph;
+  spec: GqlQuerySpec;
+  relationship: PropertyGraphRelationship | undefined;
+}> = ({ graph, spec, relationship }) => {
+  const [open, setOpen] = useState(false);
+
+  const joinPairs = (end: PropertyGraphRelationship["source"] | undefined, entityName: string) =>
+    (end?.relationshipColumns ?? []).map((column, index) => (
+      `${spec.relationshipName}.${column} = ${entityName}.${end?.entityColumns?.[index] ?? "?"}`
+    ));
+
+  const joins = [
+    ...joinPairs(relationship?.source, spec.sourceEntityName),
+    ...joinPairs(relationship?.destination, spec.destinationEntityName),
+  ];
+
+  const clauses: { code: string; text: string }[] = [
+    {
+      code: "GRAPH_TABLE( … )",
+      text: `Runs a pattern against ${graph.target.name} and hands the matches back as an ordinary table, so everything outside the brackets is normal SQL.`,
+    },
+    {
+      code: `MATCH (${spec.aliases.source}:${spec.sourceEntityName})-[${spec.aliases.edge}:${spec.relationshipName}]->(${spec.aliases.destination}:${spec.destinationEntityName})`,
+      text: `The shape to look for. Round brackets are entities, square brackets are the relationship joining them, and the arrow is its direction. ${spec.aliases.source}, ${spec.aliases.edge} and ${spec.aliases.destination} are short names you pick so the RETURN line can refer to each part.`,
+    },
+    {
+      code: "RETURN …",
+      text: "Which properties to pull out of each match. Tick properties on the diagram above to change this line.",
+    },
+    {
+      code: "LIMIT 100",
+      text: "Caps how many matches come back.",
+    },
+  ];
+
+  return (
+    <div className="rounded-lg border border-[var(--vscode-widget-border)]/60 px-3 py-2">
+      <p className="text-[11px] text-[var(--vscode-foreground)] opacity-90 m-0">
+        This finds every <span className="font-mono">{spec.sourceEntityName}</span> linked to a{" "}
+        <span className="font-mono">{spec.destinationEntityName}</span> by a{" "}
+        <span className="font-mono">{spec.relationshipName}</span>, and returns one row per link.
+      </p>
+      <button
+        type="button"
+        onClick={() => setOpen((current) => !current)}
+        className="mt-1.5 flex items-center text-[11px] text-[var(--vscode-textLink-foreground)] hover:underline"
+      >
+        {open ? <ChevronDown className="w-3 h-3 mr-1" /> : <ChevronRight className="w-3 h-3 mr-1" />}
+        {open ? "Hide" : "What each line does"}
+      </button>
+
+      {open && (
+        <div className="mt-2 space-y-2">
+          {clauses.map((clause) => (
+            <div key={clause.code}>
+              <code className="text-[11px] font-mono text-[var(--vscode-textPreformat-foreground)] break-all">
+                {clause.code}
+              </code>
+              <p className="text-[11px] text-[var(--vscode-descriptionForeground)] m-0 mt-0.5">{clause.text}</p>
+            </div>
+          ))}
+
+          {joins.length > 0 && (
+            <div className="pt-1 border-t border-[var(--vscode-widget-border)]/60">
+              <p className="text-[11px] text-[var(--vscode-descriptionForeground)] m-0 mt-1.5">
+                In plain SQL this is a join of the three tables on the keys declared in the yaml:
+              </p>
+              <ul className="list-none p-0 m-0 mt-1">
+                {joins.map((join) => (
+                  <li key={join} className="text-[11px] font-mono text-[var(--vscode-foreground)] opacity-80">
+                    {join}
+                  </li>
+                ))}
+              </ul>
+              <p className="text-[11px] text-[var(--vscode-descriptionForeground)] m-0 mt-1">
+                Writing it as a path pays off once you follow several hops, or a number of hops
+                you do not know up front — those are awkward to express as joins.
+              </p>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
 const PropertyGraphCard: React.FC<{ graph: PropertyGraph; state: WebviewState }> = ({ graph, state }) => {
   const graphKey = fullTargetName(graph.target);
   const [expanded, setExpanded] = useState<Record<string, boolean>>({});
@@ -317,6 +411,9 @@ const PropertyGraphCard: React.FC<{ graph: PropertyGraph; state: WebviewState }>
   );
 
   const activeSpec = specs[Math.min(activeSpecIndex, Math.max(specs.length - 1, 0))];
+  const activeRelationship = (graph.relationships ?? []).find(
+    (relationship) => relationship.name === activeSpec?.relationshipName,
+  );
   const starterQuery = activeSpec ? buildGqlQuery(graph, activeSpec, selection) : "";
   const validation = state.propertyGraphValidations?.find((item) => item.targetName === graphKey);
   const bodyErrorAnnotations = validation?.graphBodyLine !== undefined && validation.message
@@ -431,6 +528,9 @@ const PropertyGraphCard: React.FC<{ graph: PropertyGraph; state: WebviewState }>
             </button>
           </div>
           <CodeBlock code={starterQuery} language="sql" />
+          {activeSpec && (
+            <StarterQueryExplainer graph={graph} spec={activeSpec} relationship={activeRelationship} />
+          )}
           <p className="text-[11px] text-[var(--vscode-descriptionForeground)] m-0">
             GRAPH_TABLE reads the graph from BigQuery, so this needs the graph to have been
             created (Run graph) and a BigQuery Enterprise or Enterprise Plus reservation.

--- a/webviews/preview_compiled/components/PropertyGraphSection.tsx
+++ b/webviews/preview_compiled/components/PropertyGraphSection.tsx
@@ -1,0 +1,462 @@
+import React, { useCallback, useMemo, useState } from "react";
+import {
+  AlertTriangle,
+  Check,
+  ChevronDown,
+  ChevronRight,
+  CircleSlash,
+  Loader2,
+  Play,
+  Tag,
+} from "lucide-react";
+import clsx from "clsx";
+import { CodeBlock } from "../../components/CodeBlock";
+import { BigQueryTableLink } from "../../components/BigQueryTableLink";
+import { vscode } from "../utils/vscode";
+import type { PropertyGraph, PropertyGraphValidation, WebviewState } from "../types";
+import type { PropertyGraphEntity, PropertyGraphRelationship } from "../../../src/types";
+import {
+  buildGqlQuery,
+  buildGqlQuerySpecs,
+  defaultLabelOf,
+  elementImportsAllColumns,
+  fullTargetName,
+  knownPropertyNames,
+  type GqlSelection,
+} from "../../../src/shared/propertyGraph";
+import { PropertyGraphDiagram, PropertyList, type GraphElementView } from "./PropertyGraphDiagram";
+
+function toElementView(
+  element: PropertyGraphEntity | PropertyGraphRelationship,
+  kind: "entity" | "relationship",
+  schemas: WebviewState["propertyGraphElementSchemas"],
+  requested: Record<string, boolean>,
+  schemaKey: string,
+): GraphElementView {
+  const label = defaultLabelOf(element);
+  const importAll = elementImportsAllColumns(element);
+  const mappedFields = label?.fields ?? [];
+  const fetched = schemas?.[schemaKey];
+
+  let schemaState: GraphElementView["schemaState"] = "loaded";
+  let availableProperties: string[] = mappedFields.map((field) => field.name);
+
+  if (importAll) {
+    if (fetched?.error) {
+      schemaState = "error";
+      availableProperties = [...(element.keys ?? [])];
+    } else if (fetched) {
+      schemaState = "loaded";
+      const fetchedNames = fetched.columns.map((column) => column.name);
+      const keys = (element.keys ?? []).filter((key) => fetchedNames.includes(key));
+      availableProperties = [...keys, ...fetchedNames.filter((name) => !keys.includes(name))];
+    } else if (requested[schemaKey]) {
+      schemaState = "loading";
+      availableProperties = [...(element.keys ?? [])];
+    } else {
+      schemaState = "idle";
+      availableProperties = [...(element.keys ?? [])];
+    }
+  }
+
+  return {
+    kind,
+    name: element.name,
+    backingTable: fullTargetName(element.dataSource),
+    keys: element.keys ?? [],
+    importAll,
+    mappedFields,
+    availableProperties,
+    schemaState,
+    schemaError: fetched?.error,
+  };
+}
+
+const ValidationBanner: React.FC<{ validation: PropertyGraphValidation | undefined; dryRunning: boolean }> = ({
+  validation,
+  dryRunning,
+}) => {
+  const [showStatement, setShowStatement] = useState(false);
+
+  if (!validation) {
+    return (
+      <div className="flex items-center gap-2 text-xs text-[var(--vscode-descriptionForeground)]">
+        {dryRunning ? (
+          <>
+            <Loader2 className="w-3.5 h-3.5 animate-spin" /> Validating graph against BigQuery...
+          </>
+        ) : null}
+      </div>
+    );
+  }
+
+  const tone =
+    validation.state === "ok"
+      ? "border-[var(--vscode-charts-green)]"
+      : validation.state === "skipped"
+        ? "border-[var(--vscode-widget-border)]"
+        : "border-[var(--vscode-inputValidation-errorBorder)]";
+
+  return (
+    <div className={clsx("rounded-lg border-l-4 pl-3 py-2 bg-[var(--vscode-editor-background)]", tone)}>
+      <div className="flex items-center gap-2 text-xs">
+        {validation.state === "ok" && (
+          <>
+            <Check className="w-3.5 h-3.5 text-[var(--vscode-charts-green)]" />
+            <span className="text-[var(--vscode-foreground)]">
+              Graph validated against BigQuery — every key and property column resolves.
+            </span>
+          </>
+        )}
+        {validation.state === "skipped" && (
+          <>
+            <CircleSlash className="w-3.5 h-3.5 opacity-60" />
+            <span className="text-[var(--vscode-descriptionForeground)]">{validation.message}</span>
+          </>
+        )}
+        {validation.state === "error" && (
+          <>
+            <AlertTriangle className="w-3.5 h-3.5 text-[var(--vscode-errorForeground)] flex-shrink-0" />
+            <span className="text-[var(--vscode-errorForeground)]">
+              {validation.harnessError
+                ? "Validation could not run: the statement this extension builds around the compiled graph body was rejected. This is an extension problem, not a problem with your graph."
+                : "BigQuery rejected this graph"}
+            </span>
+          </>
+        )}
+      </div>
+
+      {validation.state === "error" && (
+        <pre className="mt-2 mr-3 text-[11px] font-mono whitespace-pre-wrap text-[var(--vscode-errorForeground)] opacity-90">
+          {validation.message}
+          {validation.graphBodyLine !== undefined && `\n(graph body line ${validation.graphBodyLine})`}
+        </pre>
+      )}
+
+      <button
+        type="button"
+        onClick={() => setShowStatement((open) => !open)}
+        className="mt-1.5 flex items-center text-[11px] text-[var(--vscode-textLink-foreground)] hover:underline"
+      >
+        {showStatement ? <ChevronDown className="w-3 h-3 mr-1" /> : <ChevronRight className="w-3 h-3 mr-1" />}
+        {showStatement ? "Hide" : "Show"} the statement used for validation
+      </button>
+      {showStatement && (
+        <div className="mt-2 mr-3">
+          <p className="text-[11px] text-[var(--vscode-descriptionForeground)] mb-1">
+            Dataform does not expose a runnable statement, so this extension wraps the compiled graph
+            body to dry run it. It is never executed and never written to your project.
+          </p>
+          <CodeBlock code={validation.statement} language="sql" showLineNumbers />
+        </div>
+      )}
+    </div>
+  );
+};
+
+const RelationshipCard: React.FC<{
+  relationship: PropertyGraphRelationship;
+  view: GraphElementView;
+  selected: string[];
+  isExpanded: boolean;
+  onToggleExpand: (elementName: string) => void;
+  onToggleProperty: (elementName: string, property: string) => void;
+}> = ({ relationship, view, selected, isExpanded, onToggleExpand, onToggleProperty }) => (
+  <div className="rounded-lg border border-[var(--vscode-widget-border)]/60 overflow-hidden">
+    <button
+      type="button"
+      onClick={() => onToggleExpand(view.name)}
+      className="w-full flex items-center px-3 py-2 text-left hover:bg-[var(--vscode-toolbar-hoverBackground)]"
+    >
+      {isExpanded ? (
+        <ChevronDown className="w-3.5 h-3.5 mr-2 opacity-60" />
+      ) : (
+        <ChevronRight className="w-3.5 h-3.5 mr-2 opacity-60" />
+      )}
+      <span className="text-sm font-semibold mr-2">{view.name}</span>
+      <span className="text-[11px] font-mono opacity-60 truncate">
+        {relationship.source?.entity} &rarr; {relationship.destination?.entity}
+      </span>
+    </button>
+    {isExpanded && (
+      <div className="px-3 pb-3 space-y-3 border-t border-[var(--vscode-widget-border)]/60 pt-2">
+        <div className="text-[11px]">
+          <span className="opacity-60 mr-2">Backing table</span>
+          <BigQueryTableLink id={view.backingTable} className="font-mono text-[var(--vscode-textLink-foreground)] hover:underline" />
+        </div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-[11px] font-mono">
+          <div>
+            <div className="opacity-60 font-sans mb-0.5">Source join</div>
+            {(relationship.source?.relationshipColumns ?? []).map((column, index) => (
+              <div key={column}>
+                {column} <span className="opacity-50">&rarr;</span>{" "}
+                {relationship.source?.entityColumns?.[index] ?? "?"}
+              </div>
+            ))}
+          </div>
+          <div>
+            <div className="opacity-60 font-sans mb-0.5">Destination join</div>
+            {(relationship.destination?.relationshipColumns ?? []).map((column, index) => (
+              <div key={column}>
+                {column} <span className="opacity-50">&rarr;</span>{" "}
+                {relationship.destination?.entityColumns?.[index] ?? "?"}
+              </div>
+            ))}
+          </div>
+        </div>
+        <div>
+          <div className="opacity-60 text-[11px] mb-1">Properties in query</div>
+          <PropertyList element={view} selected={selected} onToggleProperty={onToggleProperty} />
+        </div>
+      </div>
+    )}
+  </div>
+);
+
+const PropertyGraphCard: React.FC<{ graph: PropertyGraph; state: WebviewState }> = ({ graph, state }) => {
+  const graphKey = fullTargetName(graph.target);
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+  const [requestedSchemas, setRequestedSchemas] = useState<Record<string, boolean>>({});
+  const [activeSpecIndex, setActiveSpecIndex] = useState(0);
+  const [showBody, setShowBody] = useState(false);
+
+  const specs = useMemo(() => buildGqlQuerySpecs(graph), [graph]);
+
+  // Selection is seeded from compiled output only, so reading a backing table's schema
+  // later never rewrites the query on its own — only a checkbox does.
+  const [selection, setSelection] = useState<GqlSelection>(() => {
+    const seeded: GqlSelection = {};
+    (graph.entities ?? []).forEach((entity) => { seeded[entity.name] = knownPropertyNames(entity); });
+    (graph.relationships ?? []).forEach((relationship) => {
+      seeded[relationship.name] = knownPropertyNames(relationship);
+    });
+    return seeded;
+  });
+
+  const schemaKeyFor = useCallback((elementName: string) => `${graphKey}::${elementName}`, [graphKey]);
+
+  const entityViews = useMemo(
+    () => (graph.entities ?? []).map((entity) =>
+      toElementView(entity, "entity", state.propertyGraphElementSchemas, requestedSchemas, schemaKeyFor(entity.name))),
+    [graph.entities, state.propertyGraphElementSchemas, requestedSchemas, schemaKeyFor],
+  );
+
+  const relationshipViews = useMemo(
+    () => (graph.relationships ?? []).map((relationship) =>
+      toElementView(relationship, "relationship", state.propertyGraphElementSchemas, requestedSchemas, schemaKeyFor(relationship.name))),
+    [graph.relationships, state.propertyGraphElementSchemas, requestedSchemas, schemaKeyFor],
+  );
+
+  const elementByName = useMemo(() => {
+    const map = new Map<string, PropertyGraphEntity | PropertyGraphRelationship>();
+    (graph.entities ?? []).forEach((entity) => map.set(entity.name, entity));
+    (graph.relationships ?? []).forEach((relationship) => map.set(relationship.name, relationship));
+    return map;
+  }, [graph.entities, graph.relationships]);
+
+  const handleToggleExpand = useCallback((elementName: string) => {
+    const isOpening = expanded[elementName] !== true;
+    setExpanded((previous) => ({ ...previous, [elementName]: isOpening }));
+
+    if (!isOpening) {
+      return;
+    }
+
+    // Only importAll elements need BigQuery: everything else already names all its properties.
+    const element = elementByName.get(elementName);
+    const schemaKey = schemaKeyFor(elementName);
+    const needsSchema = element !== undefined
+      && elementImportsAllColumns(element)
+      && state.propertyGraphElementSchemas?.[schemaKey] === undefined
+      && requestedSchemas[schemaKey] !== true;
+
+    if (needsSchema) {
+      setRequestedSchemas((current) => ({ ...current, [schemaKey]: true }));
+      vscode.postMessage({
+        command: "propertyGraphElementSchema",
+        value: { elementName: schemaKey, target: element.dataSource },
+      });
+    }
+  }, [expanded, elementByName, schemaKeyFor, requestedSchemas, state.propertyGraphElementSchemas]);
+
+  const handleToggleProperty = useCallback((elementName: string, property: string) => {
+    setSelection((previous) => {
+      const current = previous[elementName] ?? [];
+      return {
+        ...previous,
+        [elementName]: current.includes(property)
+          ? current.filter((item) => item !== property)
+          : [...current, property],
+      };
+    });
+  }, []);
+
+  const diagramEdges = useMemo(
+    () => (graph.relationships ?? []).map((relationship, index) => ({
+      relationship: relationshipViews[index],
+      source: relationship.source?.entity ?? "",
+      destination: relationship.destination?.entity ?? "",
+    })),
+    [graph.relationships, relationshipViews],
+  );
+
+  const activeSpec = specs[Math.min(activeSpecIndex, Math.max(specs.length - 1, 0))];
+  const starterQuery = activeSpec ? buildGqlQuery(graph, activeSpec, selection) : "";
+  const validation = state.propertyGraphValidations?.find((item) => item.targetName === graphKey);
+  const bodyErrorAnnotations = validation?.graphBodyLine !== undefined && validation.message
+    ? [{ line: validation.graphBodyLine, message: validation.message }]
+    : undefined;
+
+  return (
+    <div className="space-y-4 rounded-xl border border-[var(--vscode-widget-border)]/60 bg-[var(--vscode-sideBar-background)] p-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-[10px] uppercase font-bold tracking-wider px-1.5 py-0.5 rounded border border-[var(--vscode-charts-purple)] text-[var(--vscode-charts-purple)]">
+          Property graph
+        </span>
+        <span className="text-sm font-semibold font-mono">{graph.target.name}</span>
+        {graph.disabled && (
+          <span className="text-[10px] uppercase font-bold tracking-wider px-1.5 py-0.5 rounded border border-[var(--vscode-widget-border)] opacity-70">
+            disabled
+          </span>
+        )}
+        <div className="flex-grow" />
+        <button
+          type="button"
+          disabled={graph.disabled}
+          onClick={() => vscode.postMessage({
+            command: "runModel",
+            value: { includeDependencies: false, includeDependents: false, fullRefresh: false },
+          })}
+          className="flex items-center px-3 py-1.5 text-xs bg-[var(--vscode-button-background)] hover:brightness-110 rounded text-[var(--vscode-button-foreground)] disabled:opacity-50"
+        >
+          <Play className="w-3 h-3 mr-1.5" /> Run graph
+        </button>
+      </div>
+
+      <div className="text-[11px] font-mono text-[var(--vscode-descriptionForeground)]">{graphKey}</div>
+
+      {graph.description && (
+        <p className="text-xs text-[var(--vscode-foreground)] opacity-80 m-0">{graph.description}</p>
+      )}
+
+      {graph.tags?.length > 0 && (
+        <div className="flex flex-wrap items-center gap-1.5">
+          <Tag className="w-3 h-3 opacity-50" />
+          {graph.tags.map((tag) => (
+            <span key={tag} className="text-[10px] px-1.5 py-0.5 rounded bg-[var(--vscode-badge-background)] text-[var(--vscode-badge-foreground)]">
+              {tag}
+            </span>
+          ))}
+        </div>
+      )}
+
+      <ValidationBanner validation={validation} dryRunning={state.dryRunning === true} />
+
+      <PropertyGraphDiagram
+        entities={entityViews}
+        edges={diagramEdges}
+        expanded={expanded}
+        selection={selection}
+        onToggleExpand={handleToggleExpand}
+        onToggleProperty={handleToggleProperty}
+      />
+      <p className="text-[11px] text-[var(--vscode-descriptionForeground)] m-0">
+        Click an entity to see its properties and choose which ones the starter query returns.
+      </p>
+
+      {relationshipViews.length > 0 && (
+        <div className="space-y-2">
+          <div className="text-xs font-semibold opacity-70">Relationships</div>
+          {(graph.relationships ?? []).map((relationship, index) => (
+            <RelationshipCard
+              key={relationship.name}
+              relationship={relationship}
+              view={relationshipViews[index]}
+              selected={selection[relationship.name] ?? []}
+              isExpanded={expanded[relationship.name] === true}
+              onToggleExpand={handleToggleExpand}
+              onToggleProperty={handleToggleProperty}
+            />
+          ))}
+        </div>
+      )}
+
+      {specs.length > 0 && (
+        <div className="space-y-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-xs font-semibold opacity-70">Starter query</span>
+            {specs.length > 1 && (
+              <select
+                value={activeSpecIndex}
+                onChange={(event) => setActiveSpecIndex(Number(event.target.value))}
+                className="text-xs bg-[var(--vscode-dropdown-background)] text-[var(--vscode-dropdown-foreground)] border border-[var(--vscode-dropdown-border)] rounded px-2 py-1"
+              >
+                {specs.map((spec, index) => (
+                  <option key={spec.relationshipName} value={index}>
+                    {spec.sourceEntityName} -[{spec.relationshipName}]&gt; {spec.destinationEntityName}
+                  </option>
+                ))}
+              </select>
+            )}
+            <div className="flex-grow" />
+            <button
+              type="button"
+              onClick={() => vscode.postMessage({
+                command: "runGeneratedQuery",
+                value: { query: starterQuery, type: "table" },
+              })}
+              className="flex items-center px-3 py-1.5 text-xs bg-[var(--vscode-button-secondaryBackground)] hover:bg-[var(--vscode-button-secondaryHoverBackground)] rounded text-[var(--vscode-button-secondaryForeground)]"
+            >
+              <Play className="w-3 h-3 mr-1.5" /> Run query
+            </button>
+          </div>
+          <CodeBlock code={starterQuery} language="sql" />
+          <p className="text-[11px] text-[var(--vscode-descriptionForeground)] m-0">
+            GRAPH_TABLE reads the graph from BigQuery, so this needs the graph to have been
+            created (Run graph) and a BigQuery Enterprise or Enterprise Plus reservation.
+          </p>
+        </div>
+      )}
+
+      <div>
+        <button
+          type="button"
+          onClick={() => setShowBody((open) => !open)}
+          className="flex items-center text-xs font-semibold opacity-70 hover:opacity-100"
+        >
+          {showBody ? <ChevronDown className="w-3.5 h-3.5 mr-1.5" /> : <ChevronRight className="w-3.5 h-3.5 mr-1.5" />}
+          Compiled graph body
+        </button>
+        {showBody && (
+          <div className="mt-2">
+            <p className="text-[11px] text-[var(--vscode-descriptionForeground)] mb-1">
+              Emitted by @dataform/core exactly as shown. The statement Dataform wraps around it is
+              not part of the compiled output — see the validation statement above.
+            </p>
+            <CodeBlock
+              code={graph.graphBody ?? ""}
+              language="sql"
+              showLineNumbers
+              errorAnnotations={bodyErrorAnnotations}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export const PropertyGraphSection: React.FC<{ state: WebviewState }> = ({ state }) => (
+  <div className="space-y-4">
+    {(state.propertyGraphs ?? []).map((graph) => (
+      // Keying on the body as well as the target remounts the card when the graph is edited,
+      // so the property selection is re-seeded from the new compiled output rather than
+      // holding on to names the graph no longer exposes.
+      <PropertyGraphCard
+        key={`${fullTargetName(graph.target)}::${graph.graphBody ?? ""}`}
+        graph={graph}
+        state={state}
+      />
+    ))}
+  </div>
+);

--- a/webviews/preview_compiled/components/PropertyGraphSection.tsx
+++ b/webviews/preview_compiled/components/PropertyGraphSection.tsx
@@ -16,6 +16,7 @@ import { vscode } from "../utils/vscode";
 import type { PropertyGraph, PropertyGraphValidation, WebviewState } from "../types";
 import type { PropertyGraphEntity, PropertyGraphRelationship } from "../../../src/types";
 import {
+  DEFAULT_GQL_ROW_LIMIT,
   buildGqlQuery,
   buildGqlQuerySpecs,
   defaultLabelOf,
@@ -238,6 +239,21 @@ const StarterQueryExplainer: React.FC<{
     ...joinPairs(relationship?.destination, spec.destinationEntityName),
   ];
 
+  // A relationship can loop back to the entity it started from, in which case the pattern spans
+  // two tables rather than three.
+  const tableCount = new Set([spec.sourceEntityName, spec.destinationEntityName]).size + 1;
+
+  // The only real semantics here come from the descriptions the author wrote in the yaml.
+  // Everything else this panel says is about GQL syntax, not about what the data means.
+  const describedElements = [
+    graph.entities?.find((entity) => entity.name === spec.sourceEntityName),
+    relationship,
+    graph.entities?.find((entity) => entity.name === spec.destinationEntityName),
+  ]
+    .filter((element, index, all) => element !== undefined && all.indexOf(element) === index)
+    .map((element) => ({ name: element!.name, description: defaultLabelOf(element!)?.description }))
+    .filter((element) => !!element.description);
+
   const clauses: { code: string; text: string }[] = [
     {
       code: "GRAPH_TABLE( … )",
@@ -252,7 +268,7 @@ const StarterQueryExplainer: React.FC<{
       text: "Which properties to pull out of each match. Tick properties on the diagram above to change this line.",
     },
     {
-      code: "LIMIT 100",
+      code: `LIMIT ${DEFAULT_GQL_ROW_LIMIT}`,
       text: "Caps how many matches come back.",
     },
   ];
@@ -284,10 +300,26 @@ const StarterQueryExplainer: React.FC<{
             </div>
           ))}
 
+          {describedElements.length > 0 && (
+            <div className="pt-1 border-t border-[var(--vscode-widget-border)]/60">
+              <p className="text-[11px] text-[var(--vscode-descriptionForeground)] m-0 mt-1.5">
+                What those names mean, from the descriptions in the yaml:
+              </p>
+              <ul className="list-none p-0 m-0 mt-1 space-y-0.5">
+                {describedElements.map((element) => (
+                  <li key={element.name} className="text-[11px] text-[var(--vscode-foreground)] opacity-80">
+                    <span className="font-mono">{element.name}</span>
+                    <span className="opacity-70"> — {element.description}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
           {joins.length > 0 && (
             <div className="pt-1 border-t border-[var(--vscode-widget-border)]/60">
               <p className="text-[11px] text-[var(--vscode-descriptionForeground)] m-0 mt-1.5">
-                In plain SQL this is a join of the three tables on the keys declared in the yaml:
+                In plain SQL this is a join of the {tableCount} tables on the keys declared in the yaml:
               </p>
               <ul className="list-none p-0 m-0 mt-1">
                 {joins.map((join) => (

--- a/webviews/preview_compiled/components/PropertyGraphSection.tsx
+++ b/webviews/preview_compiled/components/PropertyGraphSection.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useMemo, useRef, useState } from "react";
 import {
   AlertTriangle,
   Check,
@@ -161,8 +161,9 @@ const RelationshipCard: React.FC<{
   isExpanded: boolean;
   onToggleExpand: (elementName: string) => void;
   onToggleProperty: (elementName: string, property: string) => void;
-}> = ({ relationship, view, selected, isExpanded, onToggleExpand, onToggleProperty }) => (
-  <div className="rounded-lg border border-[var(--vscode-widget-border)]/60 overflow-hidden">
+  cardRef: (element: HTMLDivElement | null) => void;
+}> = ({ relationship, view, selected, isExpanded, onToggleExpand, onToggleProperty, cardRef }) => (
+  <div ref={cardRef} className="rounded-lg border border-[var(--vscode-widget-border)]/60 overflow-hidden">
     <button
       type="button"
       onClick={() => onToggleExpand(view.name)}
@@ -219,6 +220,7 @@ const PropertyGraphCard: React.FC<{ graph: PropertyGraph; state: WebviewState }>
   const [requestedSchemas, setRequestedSchemas] = useState<Record<string, boolean>>({});
   const [activeSpecIndex, setActiveSpecIndex] = useState(0);
   const [showBody, setShowBody] = useState(false);
+  const relationshipCardRefs = useRef<Record<string, HTMLDivElement | null>>({});
 
   const specs = useMemo(() => buildGqlQuerySpecs(graph), [graph]);
 
@@ -254,11 +256,10 @@ const PropertyGraphCard: React.FC<{ graph: PropertyGraph; state: WebviewState }>
     return map;
   }, [graph.entities, graph.relationships]);
 
-  const handleToggleExpand = useCallback((elementName: string) => {
-    const isOpening = expanded[elementName] !== true;
-    setExpanded((previous) => ({ ...previous, [elementName]: isOpening }));
+  const setElementExpanded = useCallback((elementName: string, open: boolean) => {
+    setExpanded((previous) => ({ ...previous, [elementName]: open }));
 
-    if (!isOpening) {
+    if (!open) {
       return;
     }
 
@@ -277,7 +278,22 @@ const PropertyGraphCard: React.FC<{ graph: PropertyGraph; state: WebviewState }>
         value: { elementName: schemaKey, target: element.dataSource },
       });
     }
-  }, [expanded, elementByName, schemaKeyFor, requestedSchemas, state.propertyGraphElementSchemas]);
+  }, [elementByName, schemaKeyFor, requestedSchemas, state.propertyGraphElementSchemas]);
+
+  const handleToggleExpand = useCallback((elementName: string) => {
+    setElementExpanded(elementName, expanded[elementName] !== true);
+  }, [expanded, setElementExpanded]);
+
+  // An edge has nowhere to expand into, so clicking one opens its card and scrolls to it.
+  const handleSelectRelationship = useCallback((relationshipName: string) => {
+    setElementExpanded(relationshipName, true);
+    requestAnimationFrame(() => {
+      relationshipCardRefs.current[relationshipName]?.scrollIntoView({
+        behavior: "smooth",
+        block: "nearest",
+      });
+    });
+  }, [setElementExpanded]);
 
   const handleToggleProperty = useCallback((elementName: string, property: string) => {
     setSelection((previous) => {
@@ -359,9 +375,12 @@ const PropertyGraphCard: React.FC<{ graph: PropertyGraph; state: WebviewState }>
         selection={selection}
         onToggleExpand={handleToggleExpand}
         onToggleProperty={handleToggleProperty}
+        onSelectRelationship={handleSelectRelationship}
       />
       <p className="text-[11px] text-[var(--vscode-descriptionForeground)] m-0">
-        Click an entity to see its properties and choose which ones the starter query returns.
+        Entities are boxes and relationships are arrows, so a relationship's table is named on
+        the arrow rather than in a box of its own. Click either to see its properties and choose
+        which ones the starter query returns.
       </p>
 
       {relationshipViews.length > 0 && (
@@ -376,6 +395,7 @@ const PropertyGraphCard: React.FC<{ graph: PropertyGraph; state: WebviewState }>
               isExpanded={expanded[relationship.name] === true}
               onToggleExpand={handleToggleExpand}
               onToggleProperty={handleToggleProperty}
+              cardRef={(element) => { relationshipCardRefs.current[relationship.name] = element; }}
             />
           ))}
         </div>

--- a/webviews/preview_compiled/hooks/useVSCodeMessage.ts
+++ b/webviews/preview_compiled/hooks/useVSCodeMessage.ts
@@ -28,6 +28,23 @@ export const useVSCodeMessage = () => {
               : (prevState.dryRunning ?? false),
         };
 
+        // Property graph state belongs to one file. A message announcing a different file
+        // must not leave the previous file's graph on screen.
+        if (message.relativeFilePath && message.relativeFilePath !== prevState.relativeFilePath) {
+          nextState.propertyGraphs = message.propertyGraphs ?? null;
+          nextState.propertyGraphValidations = message.propertyGraphValidations ?? null;
+        }
+
+        // Element schemas arrive one at a time as the user expands nodes, so they are merged
+        // into the existing map rather than replacing it.
+        if (message.propertyGraphElementSchema) {
+          nextState.propertyGraphElementSchemas = {
+            ...(prevState.propertyGraphElementSchemas ?? {}),
+            [message.propertyGraphElementSchema.elementName]: message.propertyGraphElementSchema,
+          };
+          delete (nextState as Record<string, unknown>).propertyGraphElementSchema;
+        }
+
         // When starting a new compilation or dry run, clear old errors and stats 
         // to prevent stale data from persisting until new results arrive.
         if (message.recompiling === true || message.dryRunning === true) {

--- a/webviews/preview_compiled/index.css
+++ b/webviews/preview_compiled/index.css
@@ -1,3 +1,8 @@
+/* Must stay ahead of the tailwind directives: a CSS @import has to come first.
+   Imported here rather than from the diagram component so the rules land in
+   preview_compiled.css, which is the only stylesheet the panel loads. */
+@import "@xyflow/react/dist/style.css";
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/webviews/preview_compiled/types.ts
+++ b/webviews/preview_compiled/types.ts
@@ -1,7 +1,9 @@
 import { CompilationErrorType } from "../../src/types";
 import type { WorkflowUrlEntry, FailedAction, WorkflowAction, ActionCounts, ProjectConfig, BigQueryDryRunResponse } from "../../src/types";
+import type { PropertyGraph, PropertyGraphValidation, PropertyGraphElementSchema } from "../../src/types";
 export { CompilationErrorType };
 export type { WorkflowUrlEntry, FailedAction, WorkflowAction, ActionCounts, ProjectConfig, BigQueryDryRunResponse };
+export type { PropertyGraph, PropertyGraphValidation, PropertyGraphElementSchema };
 
 export interface LastModifiedTimeMetaItem {
   lastModifiedTime: string | undefined;
@@ -89,6 +91,10 @@ export interface WebviewState {
     devDependencies?: { [key: string]: string };
   };
   isHelperFile?: boolean;
+  propertyGraphs?: PropertyGraph[] | null;
+  propertyGraphValidations?: PropertyGraphValidation[] | null;
+  /** Keyed by `<graph target>::<element name>`, filled in lazily as elements are expanded. */
+  propertyGraphElementSchemas?: Record<string, PropertyGraphElementSchema>;
 }
 
 export interface Target {


### PR DESCRIPTION
Follow-up to #349. That PR taught the dependency graph and tag picker about `PropertyGraph` actions, but the compiled preview panel never learned about them — opening a property graph yaml showed an empty panel.

## Why nothing rendered

`buildIndices` only indexes `tables`, `assertions`, `operations` and `notebooks` into `FILE_NODE_MAP`, so `definitions/graph.yaml` resolves to zero file nodes, `queryMeta.type` stays `""`, `models` is empty, and `App.tsx` falls through to its compilation-error state.

The compiled output was never the problem — it carries `entities`, `relationships`, `graphBody`, `dependencyTargets`, `tags` and `disabled`. `PropertyGraph` in `types.ts` was simply missing the `entities` and `relationships` fields the compiler actually emits.

## What this adds

Property graphs now render in the Compiled Query tab:

- **Diagram** (React Flow + dagre) — entities as nodes, relationships as labelled edges. Each node expands to its property list; the backing table links out to BigQuery.
- **Relationship cards** — join keys spelled out per side, which is the easy thing to get wrong in yaml when the two ends name the key column differently (`META_ORDER_NUMBER` ↔ `ORDER_NUMBER`).
- **Graph body** — exactly as the compiler emitted it, no reconstruction.
- **Starter GQL query** — one per relationship, runnable in the query results panel.

Schema, Cost Estimator and Workflow Executions are hidden for these files: a property graph has no output schema and no bytes-scanned estimate.

## Validation, and the honest caveat

Validation dry runs a `CREATE OR REPLACE PROPERTY GRAPH` statement wrapped around the compiled body. Dataform does not expose a runnable statement, so **that wrapper is our reconstruction, not Dataform's**. Three things keep that from being a silent liability:

1. it lives in exactly one place, annotated with the core version it was verified against (3.0.69);
2. the exact SQL sent is always disclosable from the banner — the check is never a black box;
3. errors are attributed. A failure landing on the synthesised header is reported as an extension problem, not blamed on the user's graph. Errors in the body are mapped back to a `graphBody` line.

Verified with `bq query --dry_run` against a real project: *"Query successfully validated"*.

## Query generation

The `RETURN` clause is a pure function of an explicit property selection, seeded only from compiled output. Expanding an `importAll` entity reads its backing table's schema and reveals more columns to tick — but never rewrites the query on its own. Lazy schema reads stay lazy; the query never changes underneath the reader.

## Also fixed

- `runCurrentFile` now picks up graph targets (absent from `tables`), so running a property graph file no longer builds an empty action list — CLI and API paths both.
- Saving `definitions/**/*.yaml` refreshes the panel like saving a `.sqlx` does.
- A graph yaml on `@dataform/core < 3.0.65` gets an explicit version hint instead of an empty panel.
- `@xyflow/react`'s stylesheet is imported from the preview entry stylesheet. Left to code splitting it landed in a chunk this panel never loads, leaving the pane unstyled — the background `<rect>` kept its default pointer events and **swallowed every click meant for a node**, and edges were never drawn.

## Verification

`tsc`, `vite build`, `esbuild` and `eslint` clean. The generator, version gate and error classifier were exercised against real compiled output. Interaction was verified by driving the built bundle with real mouse events: node expands, checkboxes reflect the field mappings, and unticking a property removes exactly that item from `RETURN`.

One thing worth knowing: `GRAPH_TABLE` needs a BigQuery Enterprise or Enterprise Plus reservation. The generated query parses fine but will not run without one, so the UI says so under the query rather than leaving a confusing error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added property graph support in the compiled query panel, including interactive entity and relationship diagrams.
  * View graph properties, mappings, compiled definitions, validation results and generated starter queries.
  * Select properties to customise generated queries and run graphs or queries directly from the panel.
  * Automatically loads table schemas when needed and refreshes graph results after saving definition files.
  * Added a command to run generated queries from supported integrations.

* **Bug Fixes**
  * Improved handling of unavailable or non-runnable graph actions with clearer errors.
  * Added clearer validation feedback for unsupported Dataform Core versions and invalid graph definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->