### PR TITLE
fix: do not treat UNKNOWN dry run accuracy as 0 bytes processed

### DIFF
--- a/src/bigqueryDryRun.ts
+++ b/src/bigqueryDryRun.ts
@@ -61,7 +61,13 @@ export async function queryDryRun(query: string): Promise<BigQueryDryRunResponse
             dryRun: true
         });
 
-        const totalBytesProcessed = Number(parseFloat(job.metadata.statistics.totalBytesProcessed));
+        const totalBytesProcessedAccuracy = job.metadata.statistics.query?.totalBytesProcessedAccuracy;
+        const rawBytesProcessed = parseFloat(job.metadata.statistics.totalBytesProcessed);
+        const totalBytesProcessed = Number.isFinite(rawBytesProcessed) ? rawBytesProcessed : 0;
+        // When BigQuery cannot compute bytes statically it reports accuracy UNKNOWN and 0 bytes,
+        // even though the query will scan real data when executed. Flag it so consumers do not
+        // present the 0 as a genuine estimate.
+        const bytesEstimateUnknown = totalBytesProcessedAccuracy === 'UNKNOWN';
         // 1024 bytes ** 3 = 1GiB
         const cost = Number((totalBytesProcessed) / (1024 ** 3)) * bigQueryDryRunCostOneGiBByCurrency[currencyFoDryRunCost];
 
@@ -75,7 +81,8 @@ export async function queryDryRun(query: string): Promise<BigQueryDryRunResponse
                     value: cost
                 },
                 statementType: job.metadata.statistics.query.statementType,
-                totalBytesProcessedAccuracy: job.metadata.statistics.query.totalBytesProcessedAccuracy
+                totalBytesProcessedAccuracy: totalBytesProcessedAccuracy,
+                bytesEstimateUnknown: bytesEstimateUnknown
             },
             error: { hasError: false, message: "" }
         };

--- a/src/costEstimator.ts
+++ b/src/costEstimator.ts
@@ -48,9 +48,14 @@ async function getModelDryRunStats(filteredModels: Table[] | Operation[] | Asser
     }
 
     const dryRunOutput = await queryDryRun(fullQuery);
-    const costOfRunningModel = dryRunOutput?.statistics?.cost?.value || 0;
+    // BigQuery reports 0 bytes when it cannot compute them statically. Leaving the figures
+    // undefined keeps them out of the table totals instead of understating the tag's cost.
+    const bytesEstimateUnknown = dryRunOutput?.statistics?.bytesEstimateUnknown === true;
+    const costOfRunningModel = bytesEstimateUnknown ? undefined : (dryRunOutput?.statistics?.cost?.value || 0);
     // 1024 bytes ** 3 = 1GiB
-    const totalGBProcessed = ((dryRunOutput?.statistics?.totalBytesProcessed || 0) / (1024 ** 3)).toFixed(3);
+    const totalGBProcessed = bytesEstimateUnknown
+        ? undefined
+        : ((dryRunOutput?.statistics?.totalBytesProcessed || 0) / (1024 ** 3)).toFixed(3);
     const statementType = dryRunOutput?.statistics?.statementType;
     const totalBytesProcessedAccuracy = dryRunOutput?.statistics?.totalBytesProcessedAccuracy;
     const error = dryRunOutput?.error;
@@ -61,9 +66,10 @@ async function getModelDryRunStats(filteredModels: Table[] | Operation[] | Asser
         schema: curModel.target.schema,
         costOfRunningModel: costOfRunningModel,
         currency: dryRunOutput?.statistics?.cost?.currency as SupportedCurrency,
-        totalGBProcessed: totalGBProcessed || "0.000",
+        totalGBProcessed: totalGBProcessed,
         totalBytesProcessedAccuracy: totalBytesProcessedAccuracy,
         statementType: statementType,
+        bytesEstimateUnknown: bytesEstimateUnknown,
         error: error.message
     };
     });

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -4,7 +4,7 @@ globalThis.errorInPreOpsDenyList = false;
 globalThis.compilerOptionsMap = {};
 import path from 'path';
 import * as vscode from 'vscode';
-import { compileDataform, formatBytes, getQueryMetaForCurrentFile, handleSemicolonPrePostOps, buildIndices, getDataformTags } from '../../utils';
+import { compileDataform, formatBytes, formatDryRunCostSummary, getQueryMetaForCurrentFile, handleSemicolonPrePostOps, buildIndices, getDataformTags } from '../../utils';
 import { DataformCompiledJson } from '../../types';
 import { getMetadataForSqlxFileBlocks } from '../../sqlxFileParser';
 import { tableQueryOffset, incrementalTableOffset } from '../../constants';
@@ -818,6 +818,75 @@ suite('format bytes from dry run in human readable format', () => {
         assert.strictEqual(formatBytes(500), '500.00 B');
         assert.strictEqual(formatBytes(1500), '1.46 KiB');
         assert.strictEqual(formatBytes(1024 * 1024 * 1.5), '1.50 MiB');
+    });
+});
+
+suite('formatDryRunCostSummary', () => {
+    const oneGiB = 1024 ** 3;
+    const buildResult = (statistics: any, hasError = false): any => ({
+        statistics,
+        error: { hasError, message: hasError ? 'boom' : '' }
+    });
+
+    test('formats a precise estimate', () => {
+        const result = buildResult({
+            totalBytesProcessed: oneGiB,
+            cost: { currency: 'USD', value: 0.00625 },
+            totalBytesProcessedAccuracy: 'PRECISE'
+        });
+        assert.strictEqual(formatDryRunCostSummary(result, '', '$'), '1.00 GiB $0.006');
+    });
+
+    test('prefixes bound estimates and prepends the label', () => {
+        const upperBound = buildResult({
+            totalBytesProcessed: oneGiB,
+            cost: { currency: 'USD', value: 0.00625 },
+            totalBytesProcessedAccuracy: 'UPPER_BOUND'
+        });
+        assert.strictEqual(formatDryRunCostSummary(upperBound, 'Incremental', '$'), 'Incremental: Up to 1.00 GiB $0.006');
+
+        const lowerBound = buildResult({
+            totalBytesProcessed: oneGiB,
+            cost: { currency: 'USD', value: 0.00625 },
+            totalBytesProcessedAccuracy: 'LOWER_BOUND'
+        });
+        assert.strictEqual(formatDryRunCostSummary(lowerBound, '', '$'), 'At least 1.00 GiB $0.006');
+    });
+
+    test('marks UNKNOWN accuracy so 0 bytes is not read as free', () => {
+        // BigQuery reports totalBytesProcessed "0" whenever accuracy is UNKNOWN
+        const result = buildResult({
+            totalBytesProcessed: 0,
+            cost: { currency: 'USD', value: 0 },
+            statementType: 'SELECT',
+            totalBytesProcessedAccuracy: 'UNKNOWN',
+            bytesEstimateUnknown: true
+        });
+        assert.strictEqual(formatDryRunCostSummary(result, '', '$'), '0 B $0.000 \u26a0');
+    });
+
+    test('marks scripts whose bytes could not be computed', () => {
+        const result = buildResult({
+            totalBytesProcessed: 0,
+            cost: { currency: 'USD', value: 0 },
+            statementType: 'SCRIPT',
+            totalBytesProcessedAccuracy: 'UNKNOWN',
+            bytesEstimateUnknown: true
+        });
+        assert.strictEqual(
+            formatDryRunCostSummary(result, '', '$'),
+            'NOTE: Could not compute bytes processed estimate for script. \u26a0'
+        );
+    });
+
+    test('returns an empty string when there is nothing to show', () => {
+        assert.strictEqual(formatDryRunCostSummary(undefined, '', '$'), '');
+        assert.strictEqual(formatDryRunCostSummary(buildResult({ totalBytesProcessed: 0 }), '', '$'), '');
+        const erroredResult = buildResult({
+            totalBytesProcessed: 0,
+            cost: { currency: 'USD', value: 0 }
+        }, true);
+        assert.strictEqual(formatDryRunCostSummary(erroredResult, '', '$'), '');
     });
 });
 

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -853,7 +853,7 @@ suite('formatDryRunCostSummary', () => {
         assert.strictEqual(formatDryRunCostSummary(lowerBound, '', '$'), 'At least 1.00 GiB $0.006');
     });
 
-    test('marks UNKNOWN accuracy so 0 bytes is not read as free', () => {
+    test('replaces the 0 bytes UNKNOWN reports with a warning', () => {
         // BigQuery reports totalBytesProcessed "0" whenever accuracy is UNKNOWN
         const result = buildResult({
             totalBytesProcessed: 0,
@@ -862,20 +862,30 @@ suite('formatDryRunCostSummary', () => {
             totalBytesProcessedAccuracy: 'UNKNOWN',
             bytesEstimateUnknown: true
         });
-        assert.strictEqual(formatDryRunCostSummary(result, '', '$'), '0 B $0.000 \u26a0');
+        assert.strictEqual(formatDryRunCostSummary(result, '', '$'), '\u26a0 Bytes unknown');
+        assert.strictEqual(formatDryRunCostSummary(result, 'Incremental', '$'), 'Incremental: \u26a0 Bytes unknown');
     });
 
-    test('marks scripts whose bytes could not be computed', () => {
-        const result = buildResult({
+    test('warns for scripts whose bytes could not be computed', () => {
+        const unknownScript = buildResult({
             totalBytesProcessed: 0,
             cost: { currency: 'USD', value: 0 },
             statementType: 'SCRIPT',
             totalBytesProcessedAccuracy: 'UNKNOWN',
             bytesEstimateUnknown: true
         });
+        assert.strictEqual(formatDryRunCostSummary(unknownScript, '', '$'), '\u26a0 Bytes unknown');
+
+        // A script with a non-precise but known accuracy keeps the existing note
+        const lowerBoundScript = buildResult({
+            totalBytesProcessed: 0,
+            cost: { currency: 'USD', value: 0 },
+            statementType: 'SCRIPT',
+            totalBytesProcessedAccuracy: 'LOWER_BOUND'
+        });
         assert.strictEqual(
-            formatDryRunCostSummary(result, '', '$'),
-            'NOTE: Could not compute bytes processed estimate for script. \u26a0'
+            formatDryRunCostSummary(lowerBoundScript, '', '$'),
+            'NOTE: Could not compute bytes processed estimate for script.'
         );
     });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -333,6 +333,12 @@ export interface BigQueryDryRunResponse {
         };
         statementType?: string;
         totalBytesProcessedAccuracy?: string;
+        /**
+         * BigQuery could not compute bytes statically (totalBytesProcessedAccuracy === "UNKNOWN"),
+         * so it reports totalBytesProcessed as 0. The query still scans data when executed, so
+         * treat 0 bytes / 0 cost as "no estimate available" rather than as a real zero.
+         */
+        bytesEstimateUnknown?: boolean;
     };
     error: DryRunErorr
 }
@@ -381,11 +387,14 @@ export type TagDryRunStats = {
     type: string;
     targetName: string;
     schema: string;
-    costOfRunningModel: number;
+    /** undefined when BigQuery could not estimate bytes (accuracy UNKNOWN). */
+    costOfRunningModel: number | undefined;
     currency: SupportedCurrency;
-    totalGBProcessed: string;
+    /** undefined when BigQuery could not estimate bytes (accuracy UNKNOWN). */
+    totalGBProcessed: string | undefined;
     totalBytesProcessedAccuracy: string | undefined;
     statementType: string | undefined;
+    bytesEstimateUnknown?: boolean;
     error: string
 };
 

--- a/src/utils/dataformHelpers.ts
+++ b/src/utils/dataformHelpers.ts
@@ -56,15 +56,15 @@ export function formatBytes(bytes: number) {
  * Webviews look for this marker to attach a warning tooltip explaining that the
  * reported 0 bytes / 0 cost is not a real estimate.
  */
-export const UNKNOWN_ACCURACY_MARKER = ' \u26a0';
+export const UNKNOWN_ACCURACY_STAT = '\u26a0 Bytes unknown';
 
-/** Tooltip shown next to a stat carrying UNKNOWN_ACCURACY_MARKER. */
-export const UNKNOWN_ACCURACY_TOOLTIP = 'BigQuery could not estimate the bytes this query scans (totalBytesProcessedAccuracy: UNKNOWN), so it reports 0 bytes. The query will still scan data when executed \u2014 treat this as "no estimate", not as free.';
+/** Tooltip shown on a stat ending in UNKNOWN_ACCURACY_STAT. */
+export const UNKNOWN_ACCURACY_TOOLTIP = 'BigQuery could not estimate the bytes this query scans (totalBytesProcessedAccuracy: UNKNOWN), so it reports 0 bytes and 0 cost. The query will still scan data when executed \u2014 treat this as "no estimate", not as free.';
 
 /**
  * Formats a dry run result into the short stat string shown in the compiled query panel,
- * e.g. "Incremental: Up to 1.20 GiB $0.006".
- * Returns "" when there is no usable estimate to show.
+ * e.g. "Incremental: Up to 1.20 GiB $0.006", or "Incremental: \u26a0 Bytes unknown" when
+ * BigQuery could not estimate the bytes. Returns "" when there is nothing to show.
  */
 export function formatDryRunCostSummary(result: BigQueryDryRunResponse | undefined, type: string, currencySymbol: string): string {
     if (!result?.statistics?.cost || result?.error?.hasError !== false) {
@@ -76,14 +76,19 @@ export function formatDryRunCostSummary(result: BigQueryDryRunResponse | undefin
     const isLowerBound = accuracy === 'LOWER_BOUND';
     const prefix = isUpperBound ? "Up to " : (isLowerBound ? "At least " : "");
     const label = type ? type + ": " : "";
-    // BigQuery reports 0 bytes when it cannot compute them statically; warn instead of implying the query is free
-    const suffix = result.statistics.bytesEstimateUnknown ? UNKNOWN_ACCURACY_MARKER : "";
 
-    if (result.statistics.statementType === 'SCRIPT' && accuracy !== 'PRECISE' && accuracy !== 'UPPER_BOUND') {
-        return label + "NOTE: Could not compute bytes processed estimate for script." + suffix;
+    // BigQuery reports 0 bytes / 0 cost when it cannot compute them statically. Showing those
+    // figures reads as "this query is free", so replace them outright with a warning the
+    // webview renders as a chip; the raw values are explained in the tooltip.
+    if (result.statistics.bytesEstimateUnknown) {
+        return label + UNKNOWN_ACCURACY_STAT;
     }
 
-    return label + prefix + formatBytes(result.statistics.totalBytesProcessed) + " " + currencySymbol + (result.statistics.cost.value.toFixed(3) || "0.00") + suffix;
+    if (result.statistics.statementType === 'SCRIPT' && accuracy !== 'PRECISE' && accuracy !== 'UPPER_BOUND') {
+        return label + "NOTE: Could not compute bytes processed estimate for script.";
+    }
+
+    return label + prefix + formatBytes(result.statistics.totalBytesProcessed) + " " + currencySymbol + (result.statistics.cost.value.toFixed(3) || "0.00");
 }
 
 export function sendNotificationToUserOnExtensionUpdate(context: vscode.ExtensionContext) {

--- a/src/utils/dataformHelpers.ts
+++ b/src/utils/dataformHelpers.ts
@@ -6,7 +6,7 @@ import { logger } from '../logger';
 import { GitService } from '../gitClient';
 import { DataformTools } from "@ashishalex/dataform-tools";
 import { sendWorkflowInvocationNotification, syncAndrunDataformRemotely } from "../dataformApiUtils";
-import { CurrentFileMetadata, Target, Table, Operation, Assertion, Declarations, ExecutionMode } from '../types';
+import { BigQueryDryRunResponse, CurrentFileMetadata, Target, Table, Operation, Assertion, Declarations, ExecutionMode } from '../types';
 import { getWorkspaceFolder, selectWorkspaceFolder, getFileNameFromDocument, getAllFilesWtAnExtension } from './workspaceUtils';
 import { runCompilation, getOrCompileDataformJson, getDataformCompilationTimeoutFromConfig, getDataformCompilerOptions, getDataformExecutionTimeoutFromConfig, getDataformCliCmdBasedOnScope } from './dataformCompiler';
 import { getQueryMetaForCurrentFile } from './queryMetadata';
@@ -49,6 +49,41 @@ export function formatBytes(bytes: number) {
     const value = (bytes / Math.pow(k, i)).toFixed(2);
 
     return `${value} ${units[i]}`;
+}
+
+/**
+ * Suffix appended to a dry run stat line when BigQuery reported accuracy UNKNOWN.
+ * Webviews look for this marker to attach a warning tooltip explaining that the
+ * reported 0 bytes / 0 cost is not a real estimate.
+ */
+export const UNKNOWN_ACCURACY_MARKER = ' \u26a0';
+
+/** Tooltip shown next to a stat carrying UNKNOWN_ACCURACY_MARKER. */
+export const UNKNOWN_ACCURACY_TOOLTIP = 'BigQuery could not estimate the bytes this query scans (totalBytesProcessedAccuracy: UNKNOWN), so it reports 0 bytes. The query will still scan data when executed \u2014 treat this as "no estimate", not as free.';
+
+/**
+ * Formats a dry run result into the short stat string shown in the compiled query panel,
+ * e.g. "Incremental: Up to 1.20 GiB $0.006".
+ * Returns "" when there is no usable estimate to show.
+ */
+export function formatDryRunCostSummary(result: BigQueryDryRunResponse | undefined, type: string, currencySymbol: string): string {
+    if (!result?.statistics?.cost || result?.error?.hasError !== false) {
+        return "";
+    }
+
+    const accuracy = result.statistics.totalBytesProcessedAccuracy;
+    const isUpperBound = accuracy === 'UPPER_BOUND';
+    const isLowerBound = accuracy === 'LOWER_BOUND';
+    const prefix = isUpperBound ? "Up to " : (isLowerBound ? "At least " : "");
+    const label = type ? type + ": " : "";
+    // BigQuery reports 0 bytes when it cannot compute them statically; warn instead of implying the query is free
+    const suffix = result.statistics.bytesEstimateUnknown ? UNKNOWN_ACCURACY_MARKER : "";
+
+    if (result.statistics.statementType === 'SCRIPT' && accuracy !== 'PRECISE' && accuracy !== 'UPPER_BOUND') {
+        return label + "NOTE: Could not compute bytes processed estimate for script." + suffix;
+    }
+
+    return label + prefix + formatBytes(result.statistics.totalBytesProcessed) + " " + currencySymbol + (result.statistics.cost.value.toFixed(3) || "0.00") + suffix;
 }
 
 export function sendNotificationToUserOnExtensionUpdate(context: vscode.ExtensionContext) {

--- a/src/utils/dryRunOrchestrator.ts
+++ b/src/utils/dryRunOrchestrator.ts
@@ -236,7 +236,11 @@ export async function dryRunAndShowDiagnostics(curFileMeta: any, document: vscod
             let targetTableId = ` ${table.target.database}.${table.target.schema}.${table.target.name} ; `;
             combinedTableIds += targetTableId;
         });
-        vscode.window.showInformationMessage(`GB: ${dryRunResult.statistics?.totalBytesProcessed || 0} - ${combinedTableIds}`);
+        // 0 bytes with UNKNOWN accuracy is not an estimate, so say so rather than reporting 0
+        const bytesProcessedSummary = dryRunResult.statistics?.bytesEstimateUnknown
+            ? "could not be estimated by BigQuery"
+            : `${dryRunResult.statistics?.totalBytesProcessed || 0}`;
+        vscode.window.showInformationMessage(`GB: ${bytesProcessedSummary} - ${combinedTableIds}`);
     }
     return { mainQuery: dryRunResult, nonIncremental: nonIncrementalDryRunResult, incremental: incrementalDryRunResult, assertion: assertionDryRunResult, testQuery: testDryRunResult, expectedOutput: expectedOutputDryRunResult, perAssertionDryRunResults, perTableDryRunResults, perNonIncrementalDryRunResults, perIncrementalDryRunResults, perOperationDryRunResults, perTestDryRunResults, perExpectedOutputDryRunResults };
 }

--- a/src/views/dependency-inspector-panel.ts
+++ b/src/views/dependency-inspector-panel.ts
@@ -228,7 +228,14 @@ export function createDependencyInspectorPanel(context: vscode.ExtensionContext,
                             : undefined;
                         panel.webview.postMessage({
                             type: 'dryRunResult',
-                            value: { tableId, query, bytes, cost },
+                            value: {
+                                tableId,
+                                query,
+                                bytes,
+                                cost,
+                                // 0 bytes here only means BigQuery could not compute them statically
+                                bytesEstimateUnknown: result.statistics?.bytesEstimateUnknown === true,
+                            },
                         });
                     }
                 } catch (err: any) {

--- a/src/views/register-preview-compiled-panel.ts
+++ b/src/views/register-preview-compiled-panel.ts
@@ -1,6 +1,6 @@
 import {  ExtensionContext, Uri, WebviewPanel, window } from "vscode";
 import * as vscode from 'vscode';
-import { compiledQueryWtDryRun, dryRunAndShowDiagnostics, formatBytes, gatherQueryAutoCompletionMeta, getCurrentFileMetadata, getNonce, getTableSchema, getWorkspaceFolder, handleSemicolonPrePostOps, selectWorkspaceFolder, openFileOnLeftEditorPane, findModelFromTarget, getPostionOfSourceDeclaration, showLoadingProgress, executableIsAvailable, readDataformCoreVersion, getRelativePath, deriveNodeMapsFromQueryMeta } from "../utils";
+import { compiledQueryWtDryRun, dryRunAndShowDiagnostics, formatDryRunCostSummary, gatherQueryAutoCompletionMeta, getCurrentFileMetadata, getNonce, getTableSchema, getWorkspaceFolder, handleSemicolonPrePostOps, selectWorkspaceFolder, openFileOnLeftEditorPane, findModelFromTarget, getPostionOfSourceDeclaration, showLoadingProgress, executableIsAvailable, readDataformCoreVersion, getRelativePath, deriveNodeMapsFromQueryMeta } from "../utils";
 import path from "path";
 import { getLiniageMetadata } from "../getLineageMetadata";
 import { runCurrentFile } from "../runCurrentFile";
@@ -1017,22 +1017,7 @@ export class CompiledQueryPanel {
             currencySymbol = currencySymbolMapping[currency];
         }
 
-        const formatCost = (result: any, type: string) => {
-            if(result?.statistics?.cost && result?.error?.hasError === false){
-                const isUpperBound = result.statistics.totalBytesProcessedAccuracy === 'UPPER_BOUND';
-                const isLowerBound = result.statistics.totalBytesProcessedAccuracy === 'LOWER_BOUND';
-                const prefix = isUpperBound ? "Up to " : (isLowerBound ? "At least " : "");
-
-                if (result.statistics.statementType === 'SCRIPT' && 
-                    result.statistics.totalBytesProcessedAccuracy !== 'PRECISE' && 
-                    result.statistics.totalBytesProcessedAccuracy !== 'UPPER_BOUND') {
-                    return (type ? type + ": " : "") + "NOTE: Could not compute bytes processed estimate for script.";
-                }
-
-                return (type ? type + ": " : "") + prefix + formatBytes(result?.statistics?.totalBytesProcessed) + " " + currencySymbol + (result?.statistics?.cost?.value.toFixed(3) || "0.00");
-            }
-            return "";
-        };
+        const formatCost = (result: BigQueryDryRunResponse | undefined, type: string) => formatDryRunCostSummary(result, type, currencySymbol);
 
         const isJsFile = fileMetadata.queryMeta.type === "js";
 

--- a/webviews/dependency-inspector/App.tsx
+++ b/webviews/dependency-inspector/App.tsx
@@ -8,6 +8,7 @@ import { FindWidget } from '../components/FindWidget';
 import DependencyGraph from './DependencyGraph';
 import { BigQueryTableLink } from '../components/BigQueryTableLink';
 import { AutoGrowingTextarea } from '../components/AutoGrowingTextarea';
+import { UNKNOWN_ACCURACY_TOOLTIP } from '../utils/dryRunAccuracy';
 
 // ─────────────────────────────────────────────────────────────
 // Helpers
@@ -317,7 +318,7 @@ export default function App() {
                 }
 
                 case 'dryRunResult': {
-                    const { tableId, bytes, cost, error, query } = msg.value;
+                    const { tableId, bytes, cost, error, query, bytesEstimateUnknown } = msg.value;
                     setResults(prev => ({
                         ...prev,
                         [tableId]: {
@@ -325,6 +326,7 @@ export default function App() {
                             query,
                             bytes,
                             cost,
+                            bytesEstimateUnknown,
                             error,
                         },
                     }));
@@ -1276,12 +1278,28 @@ export default function App() {
                                                     <span>
                                                         <span className="text-[var(--vscode-descriptionForeground)]">Bytes processed: </span>
                                                         <span className="font-mono font-semibold">{res.bytes}</span>
+                                                        {res.bytesEstimateUnknown && (
+                                                            <span
+                                                                className="ml-1 text-[var(--vscode-editorWarning-foreground)]"
+                                                                title={UNKNOWN_ACCURACY_TOOLTIP}
+                                                            >
+                                                                ⚠
+                                                            </span>
+                                                        )}
                                                     </span>
                                                 )}
                                                 {res.cost && (
                                                     <span>
                                                         <span className="text-[var(--vscode-descriptionForeground)]">Estimated cost: </span>
                                                         <span className="font-mono font-semibold">{res.cost}</span>
+                                                        {res.bytesEstimateUnknown && (
+                                                            <span
+                                                                className="ml-1 text-[var(--vscode-editorWarning-foreground)]"
+                                                                title={UNKNOWN_ACCURACY_TOOLTIP}
+                                                            >
+                                                                ⚠
+                                                            </span>
+                                                        )}
                                                     </span>
                                                 )}
                                             </div>

--- a/webviews/dependency-inspector/App.tsx
+++ b/webviews/dependency-inspector/App.tsx
@@ -8,7 +8,7 @@ import { FindWidget } from '../components/FindWidget';
 import DependencyGraph from './DependencyGraph';
 import { BigQueryTableLink } from '../components/BigQueryTableLink';
 import { AutoGrowingTextarea } from '../components/AutoGrowingTextarea';
-import { UNKNOWN_ACCURACY_TOOLTIP } from '../utils/dryRunAccuracy';
+import { UNKNOWN_ACCURACY_CHIP_STYLE, UNKNOWN_ACCURACY_STAT, UNKNOWN_ACCURACY_TOOLTIP } from '../utils/dryRunAccuracy';
 
 // ─────────────────────────────────────────────────────────────
 // Helpers
@@ -1274,33 +1274,30 @@ export default function App() {
                                         {/* Dry run stats */}
                                         {res.status === 'dry-run-success' && (
                                             <div className="flex gap-4 text-xs text-[var(--vscode-foreground)]">
-                                                {res.bytes && (
-                                                    <span>
-                                                        <span className="text-[var(--vscode-descriptionForeground)]">Bytes processed: </span>
-                                                        <span className="font-mono font-semibold">{res.bytes}</span>
-                                                        {res.bytesEstimateUnknown && (
-                                                            <span
-                                                                className="ml-1 text-[var(--vscode-editorWarning-foreground)]"
-                                                                title={UNKNOWN_ACCURACY_TOOLTIP}
-                                                            >
-                                                                ⚠
+                                                {/* BigQuery reports 0 bytes / 0 cost when it could not estimate them, so show a warning in their place */}
+                                                {res.bytesEstimateUnknown ? (
+                                                    <span
+                                                        className="px-1.5 py-0.5 rounded font-semibold"
+                                                        style={UNKNOWN_ACCURACY_CHIP_STYLE}
+                                                        title={UNKNOWN_ACCURACY_TOOLTIP}
+                                                    >
+                                                        {UNKNOWN_ACCURACY_STAT}
+                                                    </span>
+                                                ) : (
+                                                    <>
+                                                        {res.bytes && (
+                                                            <span>
+                                                                <span className="text-[var(--vscode-descriptionForeground)]">Bytes processed: </span>
+                                                                <span className="font-mono font-semibold">{res.bytes}</span>
                                                             </span>
                                                         )}
-                                                    </span>
-                                                )}
-                                                {res.cost && (
-                                                    <span>
-                                                        <span className="text-[var(--vscode-descriptionForeground)]">Estimated cost: </span>
-                                                        <span className="font-mono font-semibold">{res.cost}</span>
-                                                        {res.bytesEstimateUnknown && (
-                                                            <span
-                                                                className="ml-1 text-[var(--vscode-editorWarning-foreground)]"
-                                                                title={UNKNOWN_ACCURACY_TOOLTIP}
-                                                            >
-                                                                ⚠
+                                                        {res.cost && (
+                                                            <span>
+                                                                <span className="text-[var(--vscode-descriptionForeground)]">Estimated cost: </span>
+                                                                <span className="font-mono font-semibold">{res.cost}</span>
                                                             </span>
                                                         )}
-                                                    </span>
+                                                    </>
                                                 )}
                                             </div>
                                         )}

--- a/webviews/dependency-inspector/types.ts
+++ b/webviews/dependency-inspector/types.ts
@@ -40,6 +40,8 @@ export interface ModelResult {
     // Dry run stats
     bytes?: string;
     cost?: string;
+    /** BigQuery reported accuracy UNKNOWN, so `bytes`/`cost` are not a real estimate. */
+    bytesEstimateUnknown?: boolean;
     // Query results
     results?: any[];
     columns?: any[];

--- a/webviews/preview_compiled/components/CompiledQueryTab.tsx
+++ b/webviews/preview_compiled/components/CompiledQueryTab.tsx
@@ -28,6 +28,7 @@ import { CompilerOverrides } from "./CompilerOverrides";
 import StyledMultiSelect from "../../dependancy_graph/components/StyledMultiSelect";
 import { OptionType } from "../../dependancy_graph/components/StyledSelect";
 import { MultiValue } from "react-select";
+import { UNKNOWN_ACCURACY_MARKER, UNKNOWN_ACCURACY_TOOLTIP } from "../../utils/dryRunAccuracy";
 
 const ACCENT_EXPLORE = "inset 2px 0 0 var(--vscode-charts-green)";
 const ACCENT_PREVIEW = "inset 2px 0 0 var(--vscode-charts-blue)";
@@ -35,6 +36,23 @@ const ACCENT_RUN = "inset 2px 0 0 var(--vscode-charts-purple)";
 
 
 
+
+/**
+ * Dry run stat lines carrying UNKNOWN_ACCURACY_MARKER report 0 bytes only because BigQuery
+ * could not compute them statically. Render the warning glyph so it is visually distinct
+ * from the number and hangs a tooltip explaining what the 0 means.
+ */
+const renderDryRunStatLine = (line: string) => {
+  if (!line.endsWith(UNKNOWN_ACCURACY_MARKER)) {
+    return line;
+  }
+  return (
+    <span title={UNKNOWN_ACCURACY_TOOLTIP}>
+      {line.slice(0, -UNKNOWN_ACCURACY_MARKER.length)}
+      <span className="ml-1 text-[var(--vscode-editorWarning-foreground)]">⚠</span>
+    </span>
+  );
+};
 
 interface CompiledQueryTabProps {
   state: WebviewState;
@@ -273,7 +291,7 @@ export const CompiledQueryTab: React.FC<CompiledQueryTabProps> = ({
                 {dryRunStat && !state.dryRunning && (
                   <div className="absolute top-2 right-2 text-xs font-mono font-medium text-[var(--vscode-button-foreground)] bg-[var(--vscode-button-background)] px-2 py-0.5 rounded">
                     {dryRunStat.split("<br>").map((line, i) => (
-                      <React.Fragment key={i}>{i > 0 && <br />}{line}</React.Fragment>
+                      <React.Fragment key={i}>{i > 0 && <br />}{renderDryRunStatLine(line)}</React.Fragment>
                     ))}
                   </div>
                 )}

--- a/webviews/preview_compiled/components/CompiledQueryTab.tsx
+++ b/webviews/preview_compiled/components/CompiledQueryTab.tsx
@@ -28,7 +28,7 @@ import { CompilerOverrides } from "./CompilerOverrides";
 import StyledMultiSelect from "../../dependancy_graph/components/StyledMultiSelect";
 import { OptionType } from "../../dependancy_graph/components/StyledSelect";
 import { MultiValue } from "react-select";
-import { UNKNOWN_ACCURACY_MARKER, UNKNOWN_ACCURACY_TOOLTIP } from "../../utils/dryRunAccuracy";
+import { UNKNOWN_ACCURACY_CHIP_STYLE, UNKNOWN_ACCURACY_STAT, UNKNOWN_ACCURACY_TOOLTIP } from "../../utils/dryRunAccuracy";
 
 const ACCENT_EXPLORE = "inset 2px 0 0 var(--vscode-charts-green)";
 const ACCENT_PREVIEW = "inset 2px 0 0 var(--vscode-charts-blue)";
@@ -38,18 +38,21 @@ const ACCENT_RUN = "inset 2px 0 0 var(--vscode-charts-purple)";
 
 
 /**
- * Dry run stat lines carrying UNKNOWN_ACCURACY_MARKER report 0 bytes only because BigQuery
- * could not compute them statically. Render the warning glyph so it is visually distinct
- * from the number and hangs a tooltip explaining what the 0 means.
+ * A stat line ending in UNKNOWN_ACCURACY_STAT means BigQuery could not estimate the bytes.
+ * Render it as a warning chip rather than plain text, so it is impossible to mistake for a
+ * normal estimate at a glance; the tooltip explains what BigQuery actually reported.
  */
 const renderDryRunStatLine = (line: string) => {
-  if (!line.endsWith(UNKNOWN_ACCURACY_MARKER)) {
+  if (!line.endsWith(UNKNOWN_ACCURACY_STAT)) {
     return line;
   }
+  const label = line.slice(0, -UNKNOWN_ACCURACY_STAT.length);
   return (
     <span title={UNKNOWN_ACCURACY_TOOLTIP}>
-      {line.slice(0, -UNKNOWN_ACCURACY_MARKER.length)}
-      <span className="ml-1 text-[var(--vscode-editorWarning-foreground)]">⚠</span>
+      {label}
+      <span className="px-1.5 py-0.5 rounded font-semibold" style={UNKNOWN_ACCURACY_CHIP_STYLE}>
+        {UNKNOWN_ACCURACY_STAT}
+      </span>
     </span>
   );
 };

--- a/webviews/preview_compiled/components/CostEstimatorTab.tsx
+++ b/webviews/preview_compiled/components/CostEstimatorTab.tsx
@@ -3,10 +3,11 @@ import { WebviewState } from '../types';
 import { vscode } from '../utils/vscode';
 import { Loader2, Info, AlertCircle, Download } from 'lucide-react';
 import { DataTable } from '../../components/ui/data-table';
-import { ColumnDef } from '@tanstack/react-table';
+import { ColumnDef, Row } from '@tanstack/react-table';
 import StyledMultiSelect from '../../dependancy_graph/components/StyledMultiSelect';
 import { OptionType } from '../../dependancy_graph/components/StyledSelect';
 import { MultiValue } from 'react-select';
+import { UNKNOWN_ACCURACY_TOOLTIP } from '../../utils/dryRunAccuracy';
 
 interface CostEstimatorTabProps {
   state: WebviewState;
@@ -18,9 +19,53 @@ type CostEstimateRow = {
     type: string;
     statementType: string;
     totalBytesProcessedAccuracy: string;
-    totalGBProcessed: string; // or number? <b>parseFloat</b> was used in previous implementation
-    costOfRunningModel: string;
+    // undefined when BigQuery could not estimate the bytes (accuracy UNKNOWN)
+    totalGBProcessed?: string; // or number? <b>parseFloat</b> was used in previous implementation
+    costOfRunningModel?: string;
+    bytesEstimateUnknown?: boolean;
     error?: string;
+};
+
+const UNKNOWN_CELL = (
+    <span
+        className="text-[var(--vscode-editorWarning-foreground)]"
+        title={UNKNOWN_ACCURACY_TOOLTIP}
+    >
+        unknown
+    </span>
+);
+
+/**
+ * Sums a numeric column, skipping models BigQuery could not estimate. Those rows report 0
+ * bytes, so including them would silently understate the total; the count is surfaced instead.
+ */
+const renderTotal = (
+    rows: Row<CostEstimateRow>[],
+    columnId: "totalGBProcessed" | "costOfRunningModel",
+    format: (total: number) => string,
+) => {
+    let notEstimated = 0;
+    const total = rows.reduce((sum, row) => {
+        if (row.original.bytesEstimateUnknown) {
+            notEstimated += 1;
+            return sum;
+        }
+        const val = parseFloat(row.getValue(columnId));
+        return sum + (isNaN(val) ? 0 : val);
+    }, 0);
+
+    if (notEstimated === 0) {
+        return format(total);
+    }
+
+    return (
+        <span title={UNKNOWN_ACCURACY_TOOLTIP}>
+            {format(total)}
+            <span className="ml-1 font-normal text-[var(--vscode-editorWarning-foreground)]">
+                ({notEstimated} model{notEstimated === 1 ? "" : "s"} not estimated)
+            </span>
+        </span>
+    );
 };
 
 export const CostEstimatorTab: React.FC<CostEstimatorTabProps> = ({ state }) => {
@@ -72,8 +117,8 @@ export const CostEstimatorTab: React.FC<CostEstimatorTabProps> = ({ state }) => 
               `"${row.type || ''}"`,
               `"${row.statementType || ''}"`,
               `"${row.totalBytesProcessedAccuracy || ''}"`,
-              row.totalGBProcessed !== undefined && !isNaN(Number(row.totalGBProcessed)) ? Number(row.totalGBProcessed).toFixed(2) : '',
-              row.costOfRunningModel !== undefined && !isNaN(Number(row.costOfRunningModel)) ? Number(row.costOfRunningModel).toFixed(2) : '',
+              row.bytesEstimateUnknown ? 'unknown' : (row.totalGBProcessed !== undefined && !isNaN(Number(row.totalGBProcessed)) ? Number(row.totalGBProcessed).toFixed(2) : ''),
+              row.bytesEstimateUnknown ? 'unknown' : (row.costOfRunningModel !== undefined && !isNaN(Number(row.costOfRunningModel)) ? Number(row.costOfRunningModel).toFixed(2) : ''),
               `"${(row.error || '').replace(/"/g, '""')}"`
           ];
           csvRows.push(values.join(','));
@@ -132,36 +177,37 @@ export const CostEstimatorTab: React.FC<CostEstimatorTabProps> = ({ state }) => 
       {
           accessorKey: "totalBytesProcessedAccuracy",
           header: "Accuracy",
+          cell: ({ getValue }) => {
+              const accuracy = getValue() as string;
+              if (accuracy !== "UNKNOWN") {
+                  return accuracy ?? null;
+              }
+              return (
+                  <span className="text-[var(--vscode-editorWarning-foreground)]" title={UNKNOWN_ACCURACY_TOOLTIP}>
+                      {accuracy}
+                  </span>
+              );
+          },
       },
       {
           accessorKey: "totalGBProcessed",
           header: "GiB proc.",
-          cell: ({ getValue }) => {
+          cell: ({ row, getValue }) => {
+              if (row.original.bytesEstimateUnknown) { return UNKNOWN_CELL; }
               const val = parseFloat(getValue() as string);
               return isNaN(val) ? "" : val.toFixed(2);
           },
-          footer: (info) => {
-              const total = info.table.getFilteredRowModel().rows.reduce((sum, row) => {
-                  const val = parseFloat(row.getValue("totalGBProcessed"));
-                  return sum + (isNaN(val) ? 0 : val);
-              }, 0);
-              return total.toFixed(2);
-          }
+          footer: (info) => renderTotal(info.table.getFilteredRowModel().rows, "totalGBProcessed", (total) => total.toFixed(2)),
       },
       {
           accessorKey: "costOfRunningModel",
           header: "Cost",
-          cell: ({ getValue }) => {
+          cell: ({ row, getValue }) => {
+              if (row.original.bytesEstimateUnknown) { return UNKNOWN_CELL; }
               const val = parseFloat(getValue() as string);
               return isNaN(val) ? "" : `${currencySymbol}${val.toFixed(2)}`;
           },
-          footer: (info) => {
-               const total = info.table.getFilteredRowModel().rows.reduce((sum, row) => {
-                  const val = parseFloat(row.getValue("costOfRunningModel"));
-                  return sum + (isNaN(val) ? 0 : val);
-              }, 0);
-              return `${currencySymbol}${total.toFixed(2)}`;
-          }
+          footer: (info) => renderTotal(info.table.getFilteredRowModel().rows, "costOfRunningModel", (total) => `${currencySymbol}${total.toFixed(2)}`),
       },
       {
         accessorKey: "error",

--- a/webviews/preview_compiled/components/CostEstimatorTab.tsx
+++ b/webviews/preview_compiled/components/CostEstimatorTab.tsx
@@ -7,7 +7,7 @@ import { ColumnDef, Row } from '@tanstack/react-table';
 import StyledMultiSelect from '../../dependancy_graph/components/StyledMultiSelect';
 import { OptionType } from '../../dependancy_graph/components/StyledSelect';
 import { MultiValue } from 'react-select';
-import { UNKNOWN_ACCURACY_TOOLTIP } from '../../utils/dryRunAccuracy';
+import { UNKNOWN_ACCURACY_CHIP_STYLE, UNKNOWN_ACCURACY_TOOLTIP } from '../../utils/dryRunAccuracy';
 
 interface CostEstimatorTabProps {
   state: WebviewState;
@@ -28,7 +28,8 @@ type CostEstimateRow = {
 
 const UNKNOWN_CELL = (
     <span
-        className="text-[var(--vscode-editorWarning-foreground)]"
+        className="px-1.5 py-0.5 rounded font-semibold"
+        style={UNKNOWN_ACCURACY_CHIP_STYLE}
         title={UNKNOWN_ACCURACY_TOOLTIP}
     >
         unknown

--- a/webviews/utils/dryRunAccuracy.ts
+++ b/webviews/utils/dryRunAccuracy.ts
@@ -1,0 +1,12 @@
+/**
+ * BigQuery reports `totalBytesProcessed: "0"` whenever it cannot compute the byte count
+ * statically (`totalBytesProcessedAccuracy: "UNKNOWN"`). The query still scans real data
+ * when executed, so the 0 must never be presented as a genuine estimate.
+ *
+ * Keep UNKNOWN_ACCURACY_MARKER in sync with the constant of the same name in
+ * src/utils/dataformHelpers.ts, which appends it to dry run stat strings.
+ */
+export const UNKNOWN_ACCURACY_MARKER = " ⚠";
+
+export const UNKNOWN_ACCURACY_TOOLTIP =
+  'BigQuery could not estimate the bytes this query scans (totalBytesProcessedAccuracy: UNKNOWN), so it reports 0 bytes. The query will still scan data when executed — treat this as "no estimate", not as free.';

--- a/webviews/utils/dryRunAccuracy.ts
+++ b/webviews/utils/dryRunAccuracy.ts
@@ -1,12 +1,21 @@
+import type { CSSProperties } from "react";
+
 /**
  * BigQuery reports `totalBytesProcessed: "0"` whenever it cannot compute the byte count
  * statically (`totalBytesProcessedAccuracy: "UNKNOWN"`). The query still scans real data
- * when executed, so the 0 must never be presented as a genuine estimate.
+ * when executed, so those figures must never be shown as a genuine estimate.
  *
- * Keep UNKNOWN_ACCURACY_MARKER in sync with the constant of the same name in
- * src/utils/dataformHelpers.ts, which appends it to dry run stat strings.
+ * Keep UNKNOWN_ACCURACY_STAT in sync with the constant of the same name in
+ * src/utils/dataformHelpers.ts, which emits it in place of the bytes/cost figures.
  */
-export const UNKNOWN_ACCURACY_MARKER = " ⚠";
+export const UNKNOWN_ACCURACY_STAT = "⚠ Bytes unknown";
 
 export const UNKNOWN_ACCURACY_TOOLTIP =
-  'BigQuery could not estimate the bytes this query scans (totalBytesProcessedAccuracy: UNKNOWN), so it reports 0 bytes. The query will still scan data when executed — treat this as "no estimate", not as free.';
+  'BigQuery could not estimate the bytes this query scans (totalBytesProcessedAccuracy: UNKNOWN), so it reports 0 bytes and 0 cost. The query will still scan data when executed — treat this as "no estimate", not as free.';
+
+/** Warning chip styling, shared by every surface that reports an un-estimable dry run. */
+export const UNKNOWN_ACCURACY_CHIP_STYLE: CSSProperties = {
+  backgroundColor: "var(--vscode-inputValidation-warningBackground)",
+  color: "var(--vscode-inputValidation-warningForeground, var(--vscode-editorWarning-foreground))",
+  border: "1px solid var(--vscode-inputValidation-warningBorder, var(--vscode-editorWarning-foreground))",
+};


### PR DESCRIPTION
## Problem

Whenever BigQuery cannot calculate the bytes a query will scan statically, a dry run returns:

```
totalBytesProcessedAccuracy: "UNKNOWN"
totalBytesProcessed:         "0"
```

That `0` is not an estimate — the query still scans real data when executed. The extension took it at face value, so:

- models showed `0 B $0.000`, reading as "this query is free"
- the **Cost Estimator summed those zeros into its footer totals**, silently understating the cost of running a tag

## What changed

The case is now flagged once at the source, as `statistics.bytesEstimateUnknown` on the dry run response (`src/bigqueryDryRun.ts`), and accounted for at every surface that displays it:

| Surface | Before | After |
| --- | --- | --- |
| Compiled query panel | `0 B $0.000` | `⚠ Bytes unknown` warning chip |
| Dependency inspector | `Bytes processed: 0 B` / `Estimated cost: 0.0000 USD` | same warning chip |
| Cost Estimator rows | `0.00` / `$0.00` | `unknown` chip |
| Cost Estimator totals | included the zeros | excluded, footer annotated `(N models not estimated)` |
| CSV export | `0.00` / `0.00` | `unknown` |
| Save-time notification | `GB: 0` | `GB: could not be estimated by BigQuery` |

Every chip carries a tooltip explaining what BigQuery actually reported and that the query will still scan data when run.

## Also in here

- The inline `formatCost` closure in `register-preview-compiled-panel.ts` is extracted into an exported, unit tested `formatDryRunCostSummary` in `src/utils/dataformHelpers.ts`, next to the existing `formatBytes`. All ~8 call sites route through it, so no new per-node message plumbing was needed — the existing `dryRunStatByNodeName` / `ByNodeType` string channel carries the warning.
- Hardened the byte parse: an absent `totalBytesProcessed` previously produced `NaN` that flowed into `formatBytes`.

## Notes for the reviewer

- **A `SCRIPT` whose accuracy is merely non-precise (`LOWER_BOUND`) keeps its existing "could not compute … for script" note** — only genuine `UNKNOWN` gets the chip. There is a test pinning both.
- For a multi-node model only the affected line gets the chip, e.g. `Non incremental: 4.10 GiB $0.024` / `Incremental: ⚠ Bytes unknown`, so a partially-estimable model still shows what it can.
- `TagDryRunStats.totalGBProcessed` / `costOfRunningModel` are now `| undefined` — that is what keeps un-estimable models out of the totals rather than contributing a zero.

## Verification

- `npm run check-types`, `npm run lint` and `npm run build:webviews` are clean.
- New `formatDryRunCostSummary` suite in `src/test/suite/extension.test.ts` covering PRECISE, UPPER_BOUND, LOWER_BOUND, UNKNOWN, SCRIPT+UNKNOWN, SCRIPT+LOWER_BOUND and the empty cases.
- `npm test` could **not** be run locally: the cached host at `.vscode-test/vscode-darwin-arm64-1.137.0` contains a binary named `Code` while `@vscode/test-electron` spawns `Electron`, so it fails with `ENOENT` before loading any test — pre-existing and unrelated to this change. The new assertions were instead executed standalone against a stubbed `vscode` module and all pass; CI should run the real suite.
- The webview rendering still wants a look in the Extension Development Host against a model that dry-runs to `UNKNOWN` (a multi-statement model with pre-ops, or a query over an external/wildcard table).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Clearly identifies when BigQuery cannot estimate processed bytes or costs.
  * Displays warnings instead of misleading zero-byte or zero-cost values.
  * Cost estimates, totals and CSV exports now distinguish unknown values from genuine zeroes.
  * Dry-run summaries show appropriate accuracy details for bounded, precise and script queries.

* **Bug Fixes**
  * Prevents invalid or non-finite byte estimates from producing `NaN`.
  * Excludes unestimated queries from cost and processed-data totals.

* **Tests**
  * Added coverage for precise, bounded, unknown, script, empty and errored dry-run results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->